### PR TITLE
Add project scaffolding CLI and templating utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # foundry
+
+Utilities for turning a plain project idea into a runnable Python package. The
+package ships with a small command line interface as well as programmatic APIs
+for:
+
+- Generating predictable identifiers (slug, package name, class name) from a
+  human friendly project title.
+- Rendering moustache-style templates without pulling in heavyweight
+  dependencies.
+- Scaffolding a minimal Python project ready for iteration.
+
+## Installation
+
+The project uses the `src/` layout. Install it in editable mode to experiment
+with the tooling:
+
+```bash
+pip install -e .[dev]
+```
+
+## Command line usage
+
+```
+$ python -m foundry.cli init "My Project" --directory ./my-project
+Project created at /abs/path/to/my-project
+```
+
+The `render` sub-command renders individual template files:
+
+```
+$ python -m foundry.cli render template.txt -c name=demo -o output.txt
+```
+
+## Programmatic usage
+
+```python
+from foundry import ProjectConfig, ProjectScaffolder, TemplateRenderer
+
+config = ProjectConfig.from_name("Example App", description="Demo project")
+scaffolder = ProjectScaffolder()
+project_path = scaffolder.create(config, "./example-app")
+
+renderer = TemplateRenderer()
+renderer.render_string("Hello {{ name|upper }}", {"name": "world"})
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=65.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "foundry"
+version = "0.1.0"
+description = "Utilities for scaffolding Python projects"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[project.scripts]
+foundry = "foundry.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["foundry"]

--- a/src/foundry/__init__.py
+++ b/src/foundry/__init__.py
@@ -1,0 +1,26 @@
+"""Utilities for scaffolding new Python projects.
+
+The package exposes helpers for converting human friendly project names into
+module and class identifiers, renders small Jinja-less templates, and ships a
+minimal project scaffolder that can be reused both programmatically and via the
+command line interface.
+"""
+
+from __future__ import annotations
+
+from .config import ProjectConfig
+from .naming import normalize_class_name, normalize_module_name, slugify
+from .scaffold import ProjectScaffolder
+from .template import TemplateRenderer, TemplateRenderingError
+
+__all__ = [
+    "ProjectConfig",
+    "ProjectScaffolder",
+    "TemplateRenderer",
+    "TemplateRenderingError",
+    "normalize_class_name",
+    "normalize_module_name",
+    "slugify",
+]
+
+__version__ = "0.1.0"

--- a/src/foundry/__main__.py
+++ b/src/foundry/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/foundry/cli.py
+++ b/src/foundry/cli.py
@@ -1,0 +1,123 @@
+"""Command line interface for the foundry utilities."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .config import ProjectConfig
+from .scaffold import ProjectScaffolder
+from .template import TemplateRenderer
+
+
+def _parse_key_value_pairs(pairs: Iterable[str]) -> dict[str, str]:
+    context: dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise argparse.ArgumentTypeError(
+                f"invalid key/value pair '{pair}'. Expected KEY=VALUE syntax."
+            )
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise argparse.ArgumentTypeError("keys must not be empty")
+        context[key] = value
+    return context
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Utilities for scaffolding projects")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="create a new project scaffold")
+    init_parser.add_argument("name", help="Display name for the new project")
+    init_parser.add_argument(
+        "-d",
+        "--directory",
+        type=Path,
+        default=Path.cwd(),
+        help="Target directory where the project should be created",
+    )
+    init_parser.add_argument("--package", help="Override the generated package name")
+    init_parser.add_argument("--class-name", help="Override the generated class name")
+    init_parser.add_argument("--description", default="", help="Project description")
+    init_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite existing files instead of failing",
+    )
+
+    render_parser = subparsers.add_parser(
+        "render", help="render a template file with simple moustache style placeholders"
+    )
+    render_parser.add_argument("template", type=Path, help="Path to the template file")
+    render_parser.add_argument(
+        "-c",
+        "--context",
+        metavar="KEY=VALUE",
+        action="append",
+        default=[],
+        help="Values exposed to the template renderer",
+    )
+    render_parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write the rendered template to this path instead of stdout",
+    )
+    render_parser.add_argument(
+        "--missing",
+        choices=["keep", "empty", "error"],
+        default="keep",
+        help="Behaviour when a placeholder cannot be resolved",
+    )
+
+    return parser
+
+
+def _handle_init(args: argparse.Namespace) -> int:
+    config = ProjectConfig.from_name(
+        args.name,
+        package=args.package,
+        class_name=args.class_name,
+        description=args.description,
+    )
+    renderer = TemplateRenderer()
+    scaffolder = ProjectScaffolder(renderer)
+    target = args.directory
+    target.mkdir(parents=True, exist_ok=True)
+    project_path = scaffolder.create(config, target, force=args.force)
+    print(f"Project created at {project_path}")
+    return 0
+
+
+def _handle_render(args: argparse.Namespace) -> int:
+    renderer = TemplateRenderer()
+    context = _parse_key_value_pairs(args.context)
+    rendered = renderer.render_file(args.template, context, missing=args.missing)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+        if not rendered.endswith("\n"):
+            sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "init":
+        return _handle_init(args)
+    if args.command == "render":
+        return _handle_render(args)
+    parser.error("no command provided")
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/foundry/config.py
+++ b/src/foundry/config.py
@@ -1,0 +1,92 @@
+"""Configuration helpers shared by the project scaffolder and CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .naming import normalize_class_name, normalize_module_name, slugify
+
+
+@dataclass(slots=True)
+class ProjectConfig:
+    """Derived identifiers describing a new project.
+
+    Attributes
+    ----------
+    name:
+        The display name for the project provided by the user. This value is
+        preserved verbatim and is primarily used for documentation.
+    slug:
+        A URL and filesystem friendly version of :attr:`name`.
+    package:
+        The sanitized Python package name that will be used for the ``src``
+        directory.
+    class_name:
+        A canonical class name derived from :attr:`name`. Useful for generating
+        boilerplate code such as an application entry point.
+    description:
+        A short, optional sentence describing the project. When no description
+        is provided the :class:`ProjectConfig` will fall back to a sensible
+        placeholder so templates always have something meaningful to render.
+    """
+
+    name: str
+    slug: str
+    package: str
+    class_name: str
+    description: str = ""
+
+    @classmethod
+    def from_name(
+        cls,
+        name: str,
+        *,
+        package: str | None = None,
+        class_name: str | None = None,
+        description: str = "",
+    ) -> "ProjectConfig":
+        """Build a :class:`ProjectConfig` from a human friendly project name.
+
+        Parameters
+        ----------
+        name:
+            The descriptive name chosen by the caller.
+        package:
+            Optionally override the automatically generated package name.
+        class_name:
+            Optionally override the generated class name.
+        description:
+            An optional short summary of the project.
+        """
+
+        normalized_name = " ".join(name.split())
+        if not normalized_name:
+            raise ValueError("project name must not be empty")
+
+        slug = slugify(normalized_name)
+        package_name = package or normalize_module_name(normalized_name)
+        class_identifier = class_name or normalize_class_name(normalized_name)
+        summary = description.strip()
+
+        if not summary:
+            summary = "TODO: Describe your project."
+
+        return cls(
+            name=normalized_name,
+            slug=slug,
+            package=package_name,
+            class_name=class_identifier,
+            description=summary,
+        )
+
+    def context(self) -> Mapping[str, str]:
+        """Return a dictionary compatible with the templating helpers."""
+
+        return {
+            "name": self.name,
+            "slug": self.slug,
+            "package_name": self.package,
+            "class_name": self.class_name,
+            "description": self.description,
+        }

--- a/src/foundry/naming.py
+++ b/src/foundry/naming.py
@@ -1,0 +1,85 @@
+"""String normalisation utilities used throughout the project."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Iterable
+
+__all__ = ["slugify", "normalize_module_name", "normalize_class_name"]
+
+
+_SEPARATORS = re.compile(r"[\s\-]+")
+_INVALID_IDENTIFIER = re.compile(r"[^0-9a-zA-Z_]")
+_MULTIPLE_UNDERSCORES = re.compile(r"_+")
+
+
+def _collapse_whitespace(value: str) -> str:
+    return _SEPARATORS.sub(" ", value).strip()
+
+
+def slugify(value: str | Iterable[str], *, separator: str = "-", allow_unicode: bool = False) -> str:
+    """Create a filesystem and URL friendly slug from ``value``.
+
+    Parameters
+    ----------
+    value:
+        The text to normalise. When an iterable of strings is provided the values
+        are joined with spaces before slugification.
+    separator:
+        The character used to join individual words. ``separator`` must consist
+        of a single visible ASCII character.
+    allow_unicode:
+        When ``True`` unicode characters are preserved. Otherwise the result is
+        restricted to ASCII.
+    """
+
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        value = " ".join(str(part) for part in value)
+
+    text = str(value)
+    if not allow_unicode:
+        text = unicodedata.normalize("NFKD", text)
+        text = text.encode("ascii", "ignore").decode("ascii")
+    else:
+        text = unicodedata.normalize("NFKC", text)
+
+    text = re.sub(r"[\s]+", " ", text)
+    text = re.sub(r"[^\w\- ]", "", text, flags=re.UNICODE)
+    text = text.strip().lower()
+
+    if not text:
+        return ""
+
+    collapsed = _SEPARATORS.sub(separator, text)
+    collapsed = re.sub(rf"{re.escape(separator)}+", separator, collapsed)
+    return collapsed.strip(separator)
+
+
+def normalize_module_name(name: str) -> str:
+    """Return a valid Python module identifier from ``name``."""
+
+    candidate = slugify(name, separator="_", allow_unicode=False)
+    candidate = candidate.replace("-", "_")
+    candidate = _INVALID_IDENTIFIER.sub("_", candidate)
+    candidate = _MULTIPLE_UNDERSCORES.sub("_", candidate)
+    candidate = candidate.strip("_")
+
+    if not candidate:
+        candidate = "project"
+
+    if candidate[0].isdigit():
+        candidate = f"_{candidate}"
+
+    return candidate
+
+
+def normalize_class_name(name: str) -> str:
+    """Return a canonical class name generated from ``name``."""
+
+    collapsed = _collapse_whitespace(name)
+    if not collapsed:
+        return "Project"
+
+    words = re.split(r"[\s_\-]+", collapsed)
+    return "".join(word.capitalize() for word in words if word)

--- a/src/foundry/scaffold.py
+++ b/src/foundry/scaffold.py
@@ -1,0 +1,103 @@
+"""Project scaffolding helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from .config import ProjectConfig
+from .template import TemplateRenderer
+
+__all__ = ["ProjectScaffolder"]
+
+
+README_TEMPLATE = """# {{ name }}
+
+{{ description|strip }}
+
+## Development
+
+- Create a virtual environment and install dependencies with `pip install -e .[dev]`.
+- Run the test-suite with `pytest`.
+"""
+
+PYPROJECT_TEMPLATE = """[build-system]
+requires = ["setuptools>=65.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "{{ slug }}"
+version = "0.1.0"
+description = "{{ description|strip }}"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["{{ package_name }}"]
+"""
+
+INIT_TEMPLATE = (
+    '"""Top level package for {{ name }}."""\n\n__all__ = ["__version__"]\n__version__ = "0.1.0"\n'
+)
+
+TEST_TEMPLATE = """from importlib import import_module
+
+
+def test_package_importable():
+    module = import_module("{{ package_name }}")
+    assert hasattr(module, "__version__")
+"""
+
+
+@dataclass(slots=True)
+class ProjectScaffolder:
+    """Create a minimal Python project structure."""
+
+    renderer: TemplateRenderer
+
+    def __init__(self, renderer: TemplateRenderer | None = None) -> None:
+        self.renderer = renderer or TemplateRenderer()
+
+    def create(
+        self,
+        config: ProjectConfig,
+        target_dir: str | Path,
+        *,
+        force: bool = False,
+        extra_files: Iterable[tuple[str, str]] | None = None,
+    ) -> Path:
+        """Create a new project described by ``config`` inside ``target_dir``."""
+
+        target_path = Path(target_dir).expanduser().resolve()
+        target_path.mkdir(parents=True, exist_ok=True)
+
+        context = dict(config.context())
+        context.setdefault("package_name", config.package)
+        context.setdefault("name", config.name)
+
+        files: list[tuple[str, str]] = [
+            ("README.md", README_TEMPLATE),
+            ("pyproject.toml", PYPROJECT_TEMPLATE),
+            (f"src/{config.package}/__init__.py", INIT_TEMPLATE),
+            ("tests/__init__.py", ""),
+            ("tests/test_smoke.py", TEST_TEMPLATE),
+        ]
+
+        if extra_files:
+            files.extend(extra_files)
+
+        for relative_path, template in files:
+            destination = target_path / relative_path
+            if destination.exists() and not force:
+                raise FileExistsError(f"{destination} already exists")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            rendered = self.renderer.render_string(template, context)
+            destination.write_text(rendered, encoding="utf-8")
+
+        return target_path

--- a/src/foundry/template.py
+++ b/src/foundry/template.py
@@ -1,0 +1,172 @@
+"""Lightweight string templating utilities."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, MutableMapping
+
+from .naming import normalize_class_name, normalize_module_name, slugify
+
+__all__ = [
+    "TemplateRenderer",
+    "TemplateRenderingError",
+]
+
+
+_PLACEHOLDER_PATTERN = re.compile(r"{{\s*(?P<expression>[^{}]+?)\s*}}")
+
+
+class TemplateRenderingError(RuntimeError):
+    """Raised when the renderer cannot evaluate a placeholder."""
+
+
+def _resolve_value(context: Mapping[str, Any], dotted_path: str) -> Any:
+    value: Any = context
+    for segment in dotted_path.split("."):
+        if isinstance(value, Mapping):
+            if segment not in value:
+                raise KeyError(segment)
+            value = value[segment]
+            continue
+        if hasattr(value, segment):
+            value = getattr(value, segment)
+            if callable(value):
+                value = value()
+            continue
+        raise KeyError(segment)
+    return value
+
+
+def _apply_filter(value: Any, filter_name: str, filters: Mapping[str, Callable[[Any], Any]]) -> Any:
+    try:
+        filter_func = filters[filter_name]
+    except KeyError as exc:
+        raise TemplateRenderingError(f"unknown filter '{filter_name}'") from exc
+
+    return filter_func(value)
+
+
+@dataclass(slots=True)
+class TemplateRenderer:
+    """Render templates with ``{{ placeholder|filters }}`` expressions."""
+
+    filters: MutableMapping[str, Callable[[Any], Any]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.filters:
+            self.filters.update(
+                {
+                    "upper": lambda value: str(value).upper(),
+                    "lower": lambda value: str(value).lower(),
+                    "title": lambda value: str(value).title(),
+                    "slug": lambda value: slugify(value),
+                    "module": lambda value: normalize_module_name(str(value)),
+                    "class": lambda value: normalize_class_name(str(value)),
+                    "repr": lambda value: repr(value),
+                    "strip": lambda value: str(value).strip(),
+                }
+            )
+
+    def render_string(
+        self,
+        template: str,
+        context: Mapping[str, Any],
+        *,
+        missing: str = "keep",
+    ) -> str:
+        """Render ``template`` using ``context``.
+
+        Parameters
+        ----------
+        template:
+            The template string to evaluate.
+        context:
+            Mapping providing values for placeholders.
+        missing:
+            Controls what happens when a placeholder cannot be resolved. The
+            supported policies are ``"keep"`` (return the placeholder unchanged),
+            ``"empty"`` (replace with an empty string) and ``"error"`` (raise
+            :class:`TemplateRenderingError`).
+        """
+
+        if missing not in {"keep", "empty", "error"}:
+            raise ValueError("missing must be 'keep', 'empty', or 'error'")
+
+        def substitute(match: re.Match[str]) -> str:
+            expression = match.group("expression")
+            parts = [part.strip() for part in expression.split("|") if part.strip()]
+            if not parts:
+                return match.group(0)
+
+            key, *filters = parts
+            try:
+                value = _resolve_value(context, key)
+            except KeyError:
+                if missing == "keep":
+                    return match.group(0)
+                if missing == "empty":
+                    return ""
+                raise TemplateRenderingError(f"missing value for '{key}'")
+
+            for filter_name in filters:
+                value = _apply_filter(value, filter_name, self.filters)
+
+            return str(value)
+
+        return _PLACEHOLDER_PATTERN.sub(substitute, template)
+
+    def render_file(
+        self,
+        template_path: str | Path,
+        context: Mapping[str, Any],
+        *,
+        target: str | Path | None = None,
+        encoding: str = "utf-8",
+        missing: str = "keep",
+    ) -> str:
+        """Render ``template_path`` and optionally write the result to ``target``."""
+
+        template_path = Path(template_path)
+        if not template_path.is_file():
+            raise FileNotFoundError(template_path)
+
+        text = template_path.read_text(encoding=encoding)
+        rendered = self.render_string(text, context, missing=missing)
+
+        if target is not None:
+            target_path = Path(target)
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text(rendered, encoding=encoding)
+
+        return rendered
+
+    def render_directory(
+        self,
+        template_dir: str | Path,
+        target_dir: str | Path,
+        context: Mapping[str, Any],
+        *,
+        missing: str = "keep",
+        ignore: Iterable[str] | None = None,
+    ) -> None:
+        """Render every file inside ``template_dir`` into ``target_dir``."""
+
+        template_dir = Path(template_dir)
+        target_dir = Path(target_dir)
+        if not template_dir.is_dir():
+            raise FileNotFoundError(template_dir)
+
+        ignore_patterns = set(ignore or [])
+        for source in template_dir.rglob("*"):
+            relative = source.relative_to(template_dir)
+            if any(relative.match(pattern) for pattern in ignore_patterns):
+                continue
+
+            destination = target_dir / relative
+            if source.is_dir():
+                destination.mkdir(parents=True, exist_ok=True)
+                continue
+
+            self.render_file(source, context, target=destination, missing=missing)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from foundry.cli import _parse_key_value_pairs, main
+
+
+def test_parse_key_value_pairs():
+    context = _parse_key_value_pairs(["name=demo", "version=1.0"])
+    assert context == {"name": "demo", "version": "1.0"}
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        _parse_key_value_pairs(["invalid"])
+
+
+def test_cli_init_creates_project(tmp_path: Path):
+    project_dir = tmp_path / "output"
+    exit_code = main(["init", "My Project", "--directory", str(project_dir)])
+    assert exit_code == 0
+    assert (project_dir / "README.md").exists()
+
+
+def test_cli_render_writes_to_output(tmp_path: Path):
+    template_path = tmp_path / "template.txt"
+    template_path.write_text("Hello {{ name }}", encoding="utf-8")
+    output_path = tmp_path / "output.txt"
+    exit_code = main(
+        [
+            "render",
+            str(template_path),
+            "-c",
+            "name=world",
+            "-o",
+            str(output_path),
+            "--missing",
+            "error",
+        ]
+    )
+    assert exit_code == 0
+    assert output_path.read_text(encoding="utf-8") == "Hello world"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from foundry.config import ProjectConfig
+
+
+def test_from_name_generates_expected_identifiers():
+    config = ProjectConfig.from_name("My Cool App", description="Utilities for demos")
+    assert config.name == "My Cool App"
+    assert config.slug == "my-cool-app"
+    assert config.package == "my_cool_app"
+    assert config.class_name == "MyCoolApp"
+    assert config.description == "Utilities for demos"
+
+
+def test_from_name_rejects_empty_input():
+    with pytest.raises(ValueError):
+        ProjectConfig.from_name("   ")
+
+
+def test_context_includes_defaults():
+    config = ProjectConfig.from_name("Demo")
+    context = config.context()
+    assert context["name"] == "Demo"
+    assert context["slug"] == "demo"
+    assert context["package_name"] == "demo"
+    assert context["class_name"] == "Demo"
+    assert context["description"].startswith("TODO")

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from foundry.naming import normalize_class_name, normalize_module_name, slugify
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("My Project", "my-project"),
+        ("   My    Project  ", "my-project"),
+        ("Project! @ 2025", "project-2025"),
+        ("Café ☕", "cafe"),
+        (("alpha", "beta"), "alpha-beta"),
+    ],
+)
+def test_slugify_basic(value, expected):
+    assert slugify(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("My Project", "my_project"),
+        ("123 invalid", "_123_invalid"),
+        ("Symbols*&^%", "symbols"),
+        ("", "project"),
+    ],
+)
+def test_normalize_module_name(value, expected):
+    assert normalize_module_name(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("my project", "MyProject"),
+        ("alreadyCamel", "Alreadycamel"),
+        ("---", "Project"),
+    ],
+)
+def test_normalize_class_name(value, expected):
+    assert normalize_class_name(value) == expected

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from foundry.config import ProjectConfig
+from foundry.scaffold import ProjectScaffolder
+from foundry.template import TemplateRenderer
+
+
+@pytest.fixture()
+def scaffolder() -> ProjectScaffolder:
+    return ProjectScaffolder(TemplateRenderer())
+
+
+def test_scaffolder_creates_expected_structure(tmp_path: Path, scaffolder: ProjectScaffolder):
+    config = ProjectConfig.from_name("Sample App")
+    project_dir = tmp_path / "project"
+    scaffolder.create(config, project_dir)
+
+    expected_files = [
+        project_dir / "README.md",
+        project_dir / "pyproject.toml",
+        project_dir / "src" / config.package / "__init__.py",
+        project_dir / "tests" / "__init__.py",
+        project_dir / "tests" / "test_smoke.py",
+    ]
+    for path in expected_files:
+        assert path.exists(), f"expected {path} to exist"
+
+
+def test_scaffolder_respects_force(tmp_path: Path, scaffolder: ProjectScaffolder):
+    config = ProjectConfig.from_name("Demo")
+    project_dir = tmp_path / "project"
+    scaffolder.create(config, project_dir)
+    (project_dir / "README.md").write_text("custom", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        scaffolder.create(config, project_dir)
+
+    scaffolder.create(config, project_dir, force=True)
+    assert (project_dir / "README.md").read_text(encoding="utf-8").startswith("# Demo")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from foundry.template import TemplateRenderer, TemplateRenderingError
+
+
+@pytest.fixture()
+def renderer() -> TemplateRenderer:
+    return TemplateRenderer()
+
+
+def test_render_string_with_filters(renderer: TemplateRenderer):
+    template = "Project {{ name|title }} uses module {{ module_name|module }}"
+    context = {"name": "sample app", "module_name": "Sample App"}
+    rendered = renderer.render_string(template, context)
+    assert rendered == "Project Sample App uses module sample_app"
+
+
+def test_render_string_missing_policy_keep(renderer: TemplateRenderer):
+    template = "Hello {{ missing }}"
+    assert renderer.render_string(template, {}, missing="keep") == template
+
+
+def test_render_string_missing_policy_empty(renderer: TemplateRenderer):
+    template = "Hello {{ missing }}"
+    assert renderer.render_string(template, {}, missing="empty") == "Hello "
+
+
+def test_render_string_missing_policy_error(renderer: TemplateRenderer):
+    with pytest.raises(TemplateRenderingError):
+        renderer.render_string("{{ missing }}", {}, missing="error")
+
+
+def test_render_file_round_trip(tmp_path: Path, renderer: TemplateRenderer):
+    template_path = tmp_path / "template.txt"
+    template_path.write_text("Name: {{ name }}", encoding="utf-8")
+    output_path = tmp_path / "output.txt"
+    renderer.render_file(template_path, {"name": "Demo"}, target=output_path)
+    assert output_path.read_text(encoding="utf-8") == "Name: Demo"
+
+
+def test_render_directory(tmp_path: Path, renderer: TemplateRenderer):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "file.txt").write_text("{{ name }}", encoding="utf-8")
+    target_dir = tmp_path / "output"
+    renderer.render_directory(template_dir, target_dir, {"name": "Demo"})
+    assert (target_dir / "file.txt").read_text(encoding="utf-8") == "Demo"
+
+
+def test_unknown_filter_raises(renderer: TemplateRenderer):
+    with pytest.raises(TemplateRenderingError):
+        renderer.render_string("{{ name|unknown }}", {"name": "demo"})


### PR DESCRIPTION
## Summary
- add a src-based Python package with naming helpers, configuration dataclass, lightweight template rendering, and a project scaffolder
- provide a command line interface with `init` and `render` sub-commands plus updated README documentation and packaging metadata
- cover the new functionality with pytest-based unit tests for naming, templating, scaffolding, and the CLI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f870e9d6e08322ae7cdf6442a4e304