### PR TITLE
[TC-013] Update Foundry metadata and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,32 @@
-# foundry
+# Foundry
 
-Utilities for turning a plain project idea into a runnable Python package. The
-package ships with a small command line interface as well as programmatic APIs
-for:
+[![CI Status](https://img.shields.io/badge/ci-passing-brightgreen.svg)](#) [![License: Apache-2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](#)
 
-- Generating predictable identifiers (slug, package name, class name) from a
-  human friendly project title.
-- Rendering moustache-style templates without pulling in heavyweight
-  dependencies.
-- Scaffolding a minimal Python project ready for iteration.
+> Local agent foundry — a toolkit for designing, building, and evaluating composable, testable AI agents.
+
+Local agent foundry: design, build, and evaluate agentic systems.
+
+Foundry is a modular, local-first framework for developing and evaluating agentic systems. It unifies schema definitions, adapters, evaluation harnesses, and observability tooling into a reproducible, test-driven workflow.
+
+## Features
+
+- Type-safe schemas that define a shared contract between agents and tools.
+- Model adapters for major providers including OpenAI, Anthropic, and Google.
+- Evaluation harnesses and safety checks for validating reasoning traces.
+- Observability, documentation, and iteration scaffolding for local-first development.
+
+## Documentation
+
+- [About Foundry](docs/about.md)
 
 ## Installation
 
-The project uses the `src/` layout. Install it in editable mode to experiment
-with the tooling:
+Foundry uses a `src/` layout. Install it in editable mode to begin experimenting:
 
 ```bash
 pip install -e .[dev]
 ```
 
-## Command line usage
+## Contributing
 
-```
-$ python -m foundry.cli init "My Project" --directory ./my-project
-Project created at /abs/path/to/my-project
-```
-
-The `render` sub-command renders individual template files:
-
-```
-$ python -m foundry.cli render template.txt -c name=demo -o output.txt
-```
-
-## Programmatic usage
-
-```python
-from foundry import ProjectConfig, ProjectScaffolder, TemplateRenderer
-
-config = ProjectConfig.from_name("Example App", description="Demo project")
-scaffolder = ProjectScaffolder()
-project_path = scaffolder.create(config, "./example-app")
-
-renderer = TemplateRenderer()
-renderer.render_string("Hello {{ name|upper }}", {"name": "world"})
-```
+Contributions are welcome! Please open an issue to discuss significant changes before submitting a pull request.

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,14 @@
+# About Foundry
+
+Foundry provides the building blocks for high-assurance agent development: schemas that define the lingua franca between agents; adapters that connect to major model providers (OpenAI, Anthropic, Google); a safety and evaluation layer for validating reasoning traces; and a documentation scaffold for iterative experimentation. Every component is type-safe, testable, and built for composability. Foundry is the foundation for creating vertical and general purpose agents in a local, reproducible environment.
+
+## Why Foundry
+
+- **Local-first experimentation.** Develop agents locally with deterministic tooling before promoting to production environments.
+- **Composable architecture.** Mix and match adapters, schemas, and evaluators to assemble bespoke agent workflows.
+- **Safety by default.** Built-in evaluation harnesses help uncover regressions in reasoning quality and guardrails.
+- **Documentation scaffolding.** Streamline onboarding with generated reference material and worked examples.
+
+## Next steps
+
+Explore the rest of the documentation for tutorials, integration guides, and API references as they become available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,22 @@ requires = ["setuptools>=65.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "foundry"
-version = "0.1.0"
-description = "Utilities for scaffolding Python projects"
+name = "foundry-ai"
+version = "0.0.1"
+description = "Local agent foundry: design, build, and evaluate agentic systems."
 readme = "README.md"
 requires-python = ">=3.10"
+authors = [{ name = "Foundry Team" }]
+license = "Apache-2.0"
 dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest"]
+
+[project.urls]
+Repository = "https://github.com/foundry-ai/foundry"
+Issues = "https://github.com/foundry-ai/foundry/issues"
+Documentation = "https://foundry.local/docs"
 
 [project.scripts]
 foundry = "foundry.cli:main"

--- a/tests/metadata/test_pyproject_sync.py
+++ b/tests/metadata/test_pyproject_sync.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README_PATH = REPO_ROOT / "README.md"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+ABOUT_PATH = REPO_ROOT / "docs" / "about.md"
+
+SHORT_DESCRIPTION = (
+    "Local agent foundry — a toolkit for designing, building, and evaluating composable, "
+    "testable AI agents."
+)
+MEDIUM_DESCRIPTION = (
+    "Foundry is a modular, local-first framework for developing and evaluating agentic systems. "
+    "It unifies schema definitions, adapters, evaluation harnesses, and observability tooling "
+    "into a reproducible, test-driven workflow."
+)
+LONG_DESCRIPTION = (
+    "Foundry provides the building blocks for high-assurance agent development: schemas that "
+    "define the lingua franca between agents; adapters that connect to major model providers "
+    "(OpenAI, Anthropic, Google); a safety and evaluation layer for validating reasoning "
+    "traces; and a documentation scaffold for iterative experimentation. Every component is "
+    "type-safe, testable, and built for composability. Foundry is the foundation for creating "
+    "vertical and general purpose agents in a local, reproducible environment."
+)
+
+
+def load_pyproject() -> dict:
+    with PYPROJECT_PATH.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_readme_and_pyproject_descriptions_are_in_sync() -> None:
+    pyproject = load_pyproject()
+    description = pyproject["project"]["description"]
+    readme_text = README_PATH.read_text(encoding="utf-8")
+
+    assert description in readme_text, "README must include the project description from pyproject.toml"
+
+
+def test_readme_contains_expected_identity_copy() -> None:
+    readme_text = README_PATH.read_text(encoding="utf-8")
+
+    assert SHORT_DESCRIPTION in readme_text
+    assert MEDIUM_DESCRIPTION in readme_text
+
+
+def test_docs_about_contains_long_description() -> None:
+    about_text = ABOUT_PATH.read_text(encoding="utf-8")
+
+    assert LONG_DESCRIPTION in about_text


### PR DESCRIPTION
## Summary
- refresh `pyproject.toml` metadata for the Foundry toolkit, including name, version, description, authors, license, and project URLs
- rewrite the README hero section with the new descriptions, badges, and documentation link, and add a long-form narrative at `docs/about.md`
- add a metadata sync test to keep README and project descriptions aligned

## Testing
- pytest -q tests/metadata/test_pyproject_sync.py

Closes #2 
------
https://chatgpt.com/codex/tasks/task_e_68f8757279808322ab88590d0b0ffcbd