### PR TITLE
Add PR template and CI guard for closing references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Related Task Card
+- Closes #
+
+## Summary
+- 
+
+## Verification
+- [ ] Tests
+- [ ] mypy
+- [ ] Coverage

--- a/.github/workflows/check-pr-links.yml
+++ b/.github/workflows/check-pr-links.yml
@@ -1,0 +1,25 @@
+name: Check PR closing references
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - ready_for_review
+
+jobs:
+  validate:
+    name: Validate closing reference
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Verify closing reference
+        run: python scripts/ci/check_pr_closing_ref.py

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Auto-closing Issues via PRs
+
+Pull requests created from task cards should automatically close their source issues when merged. To support this flow:
+
+- Every new PR starts from the template in `.github/pull_request_template.md`. It includes a `Closes #` placeholder under **Related Task Card**.
+- When a task card sets `auto_close: true`, Codex replaces the placeholder with the originating issue number (for example, `Closes #123`). Humans following the template should do the same when preparing PRs manually.
+- The CI workflow `.github/workflows/check-pr-links.yml` validates that the PR body contains a closing keyword (`Closes`, `Fixes`, or `Resolves`) paired with an issue number.
+- If a PR legitimately should not close an issue—such as repository-wide maintenance—you can apply the `skip-pr-link-check` label to bypass the guard.
+
+To keep CI passing:
+
+1. Leave the `Closes #` line in place and fill in the correct issue number before opening or updating the PR.
+2. Use one of the supported keywords (case-insensitive): `Closes`, `Fixes`, or `Resolves`.
+3. Ensure the issue reference includes the `#` symbol and a numeric identifier (for example, `Fixes #42`).
+4. Only remove the line when the PR carries the `skip-pr-link-check` label.
+
+Merging a PR with a valid closing reference automatically closes the referenced issue once the merge completes.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts used in CI and local tooling."""

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Continuous integration helpers."""

--- a/scripts/ci/check_pr_closing_ref.py
+++ b/scripts/ci/check_pr_closing_ref.py
@@ -1,0 +1,93 @@
+"""Guard to ensure PR bodies include a valid closing reference."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Iterable, Mapping, MutableMapping, Tuple
+
+CLOSING_PATTERN = re.compile(
+    r"(?im)\b(close|closes|fix|fixes|resolve|resolves)\s+#\d+\b"
+)
+SKIP_LABEL = "skip-pr-link-check"
+
+
+def has_closing_reference(body: str) -> bool:
+    """Return True if the PR body contains an auto-closing reference."""
+    if not body:
+        return False
+    return bool(CLOSING_PATTERN.search(body))
+
+
+def has_skip_label(labels: Iterable[Mapping[str, object]]) -> bool:
+    for label in labels or []:
+        name = label.get("name") if isinstance(label, Mapping) else None
+        if isinstance(name, str) and name.lower() == SKIP_LABEL:
+            return True
+    return False
+
+
+def check_pr_event(event: Mapping[str, object]) -> Tuple[bool, str]:
+    pr = event.get("pull_request") if isinstance(event, Mapping) else None
+    if not isinstance(pr, Mapping):
+        pr = {}
+
+    labels = pr.get("labels") if isinstance(pr, Mapping) else None
+    if not isinstance(labels, Iterable):
+        labels = []
+
+    if has_skip_label(labels):
+        return True, "Skipping closing reference check due to `skip-pr-link-check` label."
+
+    body = pr.get("body") if isinstance(pr, Mapping) else ""
+    body_str = body if isinstance(body, str) else ""
+
+    if has_closing_reference(body_str):
+        return True, "Closing reference found in PR body."
+
+    return (
+        False,
+        "PR body must include a closing keyword (e.g., `Closes #123`, `Fixes #123`, `Resolves #123`).",
+    )
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event-path",
+        default=None,
+        help="Path to the GitHub event payload JSON file. Overrides $GITHUB_EVENT_PATH if provided.",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def load_event(path: str) -> MutableMapping[str, object]:
+    with open(path, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    event_path = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        print("GITHUB_EVENT_PATH is not set and --event-path was not provided.", file=sys.stderr)
+        return 1
+
+    try:
+        event = load_event(event_path)
+    except FileNotFoundError:
+        print(f"Event payload not found at: {event_path}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Failed to parse event payload JSON: {exc}", file=sys.stderr)
+        return 1
+
+    ok, message = check_pr_event(event)
+    print(message)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/ci/test_check_pr_closing_ref.py
+++ b/tests/ci/test_check_pr_closing_ref.py
@@ -1,0 +1,79 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ci.check_pr_closing_ref import (  # noqa: E402  (import after sys.path setup)
+    check_pr_event,
+    has_closing_reference,
+    main,
+)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Closes #123",
+        "fixes #42",
+        "Resolves #999",
+        "Some text\n- closes #100",
+        "Multiple references: Fixes #1 and resolves #2",
+    ],
+)
+def test_has_closing_reference_valid(body: str) -> None:
+    assert has_closing_reference(body)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "",  # empty
+        "This PR does something",
+        "Closes 123",  # missing '#'
+        "Closes#123",  # missing space before '#'
+        "Closes #abc",  # non-numeric
+    ],
+)
+def test_has_closing_reference_invalid(body: str) -> None:
+    assert not has_closing_reference(body)
+
+
+def test_check_pr_event_skips_with_label() -> None:
+    event = {
+        "pull_request": {
+            "body": "",
+            "labels": [{"name": "skip-pr-link-check"}],
+        }
+    }
+    ok, message = check_pr_event(event)
+    assert ok
+    assert "skip" in message.lower()
+
+
+@pytest.mark.parametrize(
+    "body, expected_exit",
+    [("Closes #1", 0), ("Missing reference", 1)],
+)
+def test_main_with_event_path(tmp_path: Path, capsys, body: str, expected_exit: int) -> None:
+    event_path = tmp_path / "event.json"
+    event = {
+        "pull_request": {
+            "body": body,
+            "labels": [],
+        }
+    }
+    event_path.write_text(json.dumps(event))
+
+    exit_code = main(["--event-path", str(event_path)])
+    captured = capsys.readouterr()
+    assert exit_code == expected_exit
+    assert captured.out.strip() != ""
+    if expected_exit:
+        assert "must include" in captured.out
+    else:
+        assert "Closing reference" in captured.out


### PR DESCRIPTION
## Summary
- add a pull request template with a `Closes #` placeholder and verification checklist
- introduce a Python-based CI guard that validates closing references or honors the skip label
- document the auto-closing workflow and add targeted unit tests for the checker

## Testing
- pytest -q tests/ci/test_check_pr_closing_ref.py

Closes #14

------
https://chatgpt.com/codex/tasks/task_e_68f87b20aacc8322b148bfd5979a401a