### PR TITLE
[TC-03] Implement OpenAI adapter scaffolding

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,29 @@
+# Adapters
+
+## OpenAI mapping (non-streaming, no tools)
+
+Foundry's OpenAI adapter focuses on deterministic message translation and a
+minimal `generate()` implementation that works with a fake client. The
+implementation avoids network access and omits tool calling or streaming
+support. Instead, it concentrates on the following guarantees:
+
+- **Strict schema:** Messages are represented by the `Message` model, which
+  enforces one of three roles (`system`, `user`, `assistant`) and requires
+  non-empty string content. The converters reject any additional provider
+  fields to ensure JSON round-trips stay deterministic.
+- **Pure converters:** `messages_to_openai()` transforms a sequence of Foundry
+  messages into OpenAI's chat completion payload, while `openai_to_messages()`
+  performs the inverse. Each helper validates roles and content and raises an
+  `AdapterError` if data falls outside the supported schema.
+- **Deterministic requests:** `OpenAIAdapter.generate()` injects
+  `temperature=0` unless explicitly overridden, prevents caller supplied
+  `messages`/`stream` overrides, and raises an error when tools or streaming are
+  requested.
+- **Fake client friendly:** Tests construct a fake client exposing
+  `chat.completions.create(**kwargs)`. The adapter returns the first assistant
+  message from the response and surfaces malformed responses via `AdapterError`
+  for deterministic failure handling.
+
+These primitives establish a baseline for additional capabilities—such as tool
+calling and streaming—to be layered on in future tasks while keeping core
+behavior predictable and well tested.

--- a/src/foundry/core/__init__.py
+++ b/src/foundry/core/__init__.py
@@ -1,0 +1,12 @@
+"""Core data structures and adapter interfaces for Foundry."""
+
+from __future__ import annotations
+
+from .errors import AdapterError
+from .message import Message, MessageRole
+
+__all__ = [
+    "AdapterError",
+    "Message",
+    "MessageRole",
+]

--- a/src/foundry/core/adapters/__init__.py
+++ b/src/foundry/core/adapters/__init__.py
@@ -1,0 +1,14 @@
+"""Adapter interfaces and provider implementations."""
+
+from __future__ import annotations
+
+from .base import ModelAdapter
+from .openai import OpenAIAdapter
+from .utils import messages_to_openai, openai_to_messages
+
+__all__ = [
+    "ModelAdapter",
+    "OpenAIAdapter",
+    "messages_to_openai",
+    "openai_to_messages",
+]

--- a/src/foundry/core/adapters/base.py
+++ b/src/foundry/core/adapters/base.py
@@ -1,0 +1,25 @@
+"""Adapter interface shared by provider implementations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Any
+
+from ..message import Message
+
+
+class ModelAdapter(ABC):
+    """Abstract interface for provider-specific adapters."""
+
+    @abstractmethod
+    def generate(
+        self,
+        messages: Sequence[Message],
+        /,
+        *,
+        tools: Any | None = None,
+        stream: bool = False,
+        **options: Any,
+    ) -> Message:
+        """Generate an assistant message from the provided conversation history."""

--- a/src/foundry/core/adapters/openai.py
+++ b/src/foundry/core/adapters/openai.py
@@ -1,0 +1,141 @@
+"""OpenAI provider adapter (non-streaming, no tools)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..errors import AdapterError
+from ..message import Message, MessageRole
+from .base import ModelAdapter
+from .utils import messages_to_openai, openai_to_messages
+
+
+class OpenAIAdapter(ModelAdapter):
+    """Translate Foundry messages to OpenAI's chat completion API."""
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        default_model: str | None = None,
+        default_params: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._client = client
+        self._default_model = default_model
+        self._default_params = dict(default_params or {})
+
+        if "model" in self._default_params and self._default_model is None:
+            model_value = self._default_params.pop("model")
+            self._default_model = str(model_value)
+
+        reserved = {"messages", "stream"}
+        conflict = reserved.intersection(self._default_params)
+        if conflict:
+            joined = ", ".join(sorted(conflict))
+            msg = f"default parameters cannot include reserved keys: {joined}"
+            raise ValueError(msg)
+
+    def generate(
+        self,
+        messages: Sequence[Message],
+        /,
+        *,
+        tools: Any | None = None,
+        stream: bool = False,
+        **options: Any,
+    ) -> Message:
+        if tools not in (None, [], {}):
+            msg = "tool calling is not supported"
+            raise AdapterError(msg)
+        if stream:
+            msg = "streaming is not supported"
+            raise AdapterError(msg)
+        if not messages:
+            msg = "at least one message is required"
+            raise AdapterError(msg)
+
+        model_name = self._resolve_model(options)
+
+        request_payload = self._build_payload(messages, model_name, options)
+
+        try:
+            response = self._client.chat.completions.create(**request_payload)
+        except Exception as exc:  # pragma: no cover - transport errors
+            msg = "OpenAI client call failed"
+            raise AdapterError(msg) from exc
+
+        choice = self._extract_first_choice(response)
+        message_payload = self._extract_choice_message(choice)
+
+        assistant_messages = openai_to_messages([message_payload])
+        assistant = assistant_messages[0]
+        if assistant.role is not MessageRole.ASSISTANT:
+            msg = "OpenAI returned a non-assistant message"
+            raise AdapterError(msg)
+        return assistant
+
+    def _resolve_model(self, options: dict[str, Any]) -> str:
+        model_option = options.pop("model", None)
+        model_name = model_option or self._default_model
+        if not model_name:
+            msg = "a model name must be provided"
+            raise AdapterError(msg)
+        return str(model_name)
+
+    def _build_payload(
+        self,
+        messages: Sequence[Message],
+        model_name: str,
+        options: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        request_payload: dict[str, Any] = {"model": model_name, **self._default_params}
+        for key, value in options.items():
+            if key in {"messages", "stream"}:
+                msg = f"option '{key}' is managed by the adapter"
+                raise AdapterError(msg)
+            request_payload[key] = value
+
+        request_payload.setdefault("temperature", 0)
+        request_payload["messages"] = messages_to_openai(messages)
+        return request_payload
+
+    def _extract_first_choice(self, response: Any) -> Any:
+        choices = None
+        if isinstance(response, Mapping):
+            choices = response.get("choices")
+        else:
+            choices = getattr(response, "choices", None)
+
+        if not isinstance(choices, Sequence) or not choices:
+            msg = "OpenAI response missing choices"
+            raise AdapterError(msg)
+        return choices[0]
+
+    def _extract_choice_message(self, choice: Any) -> Mapping[str, Any]:
+        message_payload: Any
+        if isinstance(choice, Mapping):
+            message_payload = choice.get("message")
+        else:
+            message_payload = getattr(choice, "message", None)
+
+        if message_payload is None:
+            msg = "OpenAI choice missing message payload"
+            raise AdapterError(msg)
+
+        if isinstance(message_payload, Message):
+            return {"role": message_payload.role.value, "content": message_payload.content}
+
+        if hasattr(message_payload, "model_dump"):
+            dump = getattr(message_payload, "model_dump")
+            dumped = dump()
+            if not isinstance(dumped, Mapping):
+                msg = "model_dump() must return a mapping"
+                raise AdapterError(msg)
+            return dumped
+
+        if isinstance(message_payload, Mapping):
+            return message_payload
+
+        msg = "unsupported OpenAI message payload type"
+        raise AdapterError(msg)

--- a/src/foundry/core/adapters/utils.py
+++ b/src/foundry/core/adapters/utils.py
@@ -1,0 +1,67 @@
+"""Pure conversion helpers shared by adapter implementations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..errors import AdapterError
+from ..message import Message, MessageRole
+
+_ROLE_VALUES = {role.value for role in MessageRole}
+_ALLOWED_KEYS = {"role", "content"}
+
+
+def messages_to_openai(messages: Sequence[Message]) -> list[dict[str, str]]:
+    """Convert Foundry messages into the OpenAI Chat API format."""
+
+    return [{"role": message.role.value, "content": message.content} for message in messages]
+
+
+def openai_to_messages(payload: Sequence[Mapping[str, Any] | Any]) -> list[Message]:
+    """Normalize OpenAI Chat API messages into Foundry's schema."""
+
+    normalized: list[Message] = []
+    for item in payload:
+        mapping = _coerce_mapping(item)
+
+        extra = set(mapping) - _ALLOWED_KEYS
+        if extra:
+            joined = ", ".join(sorted(extra))
+            msg = f"unexpected fields in OpenAI payload: {joined}"
+            raise AdapterError(msg)
+
+        raw_role = mapping.get("role")
+        if not isinstance(raw_role, str):
+            msg = "message role must be a string"
+            raise AdapterError(msg)
+        normalized_role = raw_role.strip().lower()
+        if normalized_role not in _ROLE_VALUES:
+            msg = f"unsupported role '{raw_role}'"
+            raise AdapterError(msg)
+
+        content = mapping.get("content")
+        if not isinstance(content, str):
+            msg = "message content must be a string"
+            raise AdapterError(msg)
+        if content == "":
+            msg = "message content cannot be empty"
+            raise AdapterError(msg)
+
+        normalized.append(Message(role=MessageRole(normalized_role), content=content))
+
+    return normalized
+
+
+def _coerce_mapping(item: Mapping[str, Any] | Any) -> Mapping[str, Any]:
+    if isinstance(item, Mapping):
+        return item
+
+    if hasattr(item, "model_dump"):
+        dump = getattr(item, "model_dump")
+        result = dump()
+        if isinstance(result, Mapping):
+            return result
+
+    msg = "OpenAI payload entries must be mappings"
+    raise AdapterError(msg)

--- a/src/foundry/core/errors.py
+++ b/src/foundry/core/errors.py
@@ -1,0 +1,10 @@
+"""Custom exception types used by Foundry core utilities."""
+
+from __future__ import annotations
+
+
+class AdapterError(RuntimeError):
+    """Raised when an adapter cannot fulfil a request."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/src/foundry/core/message.py
+++ b/src/foundry/core/message.py
@@ -1,0 +1,30 @@
+"""Message schema shared across adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class MessageRole(str, Enum):
+    """Canonical role names supported by Foundry."""
+
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+
+
+@dataclass(frozen=True, slots=True)
+class Message:
+    """A single message exchanged with a language model."""
+
+    role: MessageRole
+    content: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.content, str):  # pragma: no cover - defensive
+            msg = "message content must be a string"
+            raise TypeError(msg)
+        if not self.content:
+            msg = "message content cannot be empty"
+            raise ValueError(msg)

--- a/tests/adapters/test_openai_generate_basic.py
+++ b/tests/adapters/test_openai_generate_basic.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from foundry.core import AdapterError, Message, MessageRole
+from foundry.core.adapters.openai import OpenAIAdapter
+
+
+class FakeCompletions:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        return self._response
+
+
+def build_fake_client(response: object) -> SimpleNamespace:
+    completions = FakeCompletions(response)
+    chat = SimpleNamespace(completions=completions)
+    return SimpleNamespace(chat=chat, completions=completions)
+
+
+def test_generate_returns_normalized_assistant_message() -> None:
+    response = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "All systems nominal."}},
+        ]
+    }
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+
+    prompt = [
+        Message(role=MessageRole.SYSTEM, content="Monitor"),
+        Message(role=MessageRole.USER, content="Status?"),
+    ]
+
+    result = adapter.generate(prompt)
+
+    assert result.role is MessageRole.ASSISTANT
+    assert result.content == "All systems nominal."
+
+    [call] = client.completions.calls
+    assert call["model"] == "gpt-4o-mini"
+    assert call["temperature"] == 0
+    assert call["messages"] == [
+        {"role": "system", "content": "Monitor"},
+        {"role": "user", "content": "Status?"},
+    ]
+
+
+def test_generate_requires_model_name() -> None:
+    response = {"choices": []}
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client)
+
+    with pytest.raises(AdapterError):
+        adapter.generate([Message(role=MessageRole.USER, content="Hi")])
+
+
+def test_generate_rejects_empty_messages() -> None:
+    client = build_fake_client({"choices": []})
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+
+    with pytest.raises(AdapterError):
+        adapter.generate([])
+
+
+def test_generate_rejects_streaming_and_tools() -> None:
+    response = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "noop"}},
+        ]
+    }
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+    prompt = [Message(role=MessageRole.USER, content="Hello")]
+
+    with pytest.raises(AdapterError):
+        adapter.generate(prompt, tools=[{"name": "foo"}])
+
+    with pytest.raises(AdapterError):
+        adapter.generate(prompt, stream=True)
+
+
+def test_generate_rejects_reserved_options() -> None:
+    response = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "noop"}},
+        ]
+    }
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+
+    prompt = [Message(role=MessageRole.USER, content="Hello")]
+
+    with pytest.raises(AdapterError):
+        adapter.generate(prompt, messages=[])
+
+
+def test_generate_handles_missing_message_payload() -> None:
+    response = {
+        "choices": [
+            {"index": 0},
+        ]
+    }
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+
+    with pytest.raises(AdapterError):
+        adapter.generate([Message(role=MessageRole.USER, content="Hello")])

--- a/tests/adapters/test_openai_mapping.py
+++ b/tests/adapters/test_openai_mapping.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from foundry.core import AdapterError, Message, MessageRole
+from foundry.core.adapters.utils import messages_to_openai, openai_to_messages
+
+
+def test_round_trip_preserves_roles_and_content() -> None:
+    messages = [
+        Message(role=MessageRole.SYSTEM, content="Configure"),
+        Message(role=MessageRole.USER, content="Hello"),
+        Message(role=MessageRole.ASSISTANT, content="Hi!"),
+    ]
+
+    payload = messages_to_openai(messages)
+    assert payload == [
+        {"role": "system", "content": "Configure"},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi!"},
+    ]
+
+    normalized = openai_to_messages(payload)
+    assert normalized == messages
+
+
+def test_openai_to_messages_rejects_unknown_role() -> None:
+    with pytest.raises(AdapterError):
+        openai_to_messages([
+            {"role": "tool", "content": "noop"},
+        ])
+
+
+def test_openai_to_messages_rejects_empty_content() -> None:
+    with pytest.raises(AdapterError):
+        openai_to_messages([
+            {"role": "user", "content": ""},
+        ])
+
+
+def test_openai_to_messages_rejects_extra_fields() -> None:
+    with pytest.raises(AdapterError):
+        openai_to_messages([
+            {"role": "assistant", "content": "hello", "foo": "bar"},
+        ])


### PR DESCRIPTION
## Summary
- add core message schema plus adapter base utilities for OpenAI usage
- implement OpenAI adapter with deterministic request/response handling
- cover mapping and generate flows with unit tests and adapter docs

## Testing
- pytest -q tests/adapters/test_openai_mapping.py tests/adapters/test_openai_generate_basic.py
- mypy --strict src/foundry/core/adapters

closes #11 

------
https://chatgpt.com/codex/tasks/task_e_68f93a8c36948322ab176825298cd13a