### PR TITLE
[TC-04] Allow case-insensitive branch name validation

### DIFF
--- a/.github/workflows/check-branch-naming.yml
+++ b/.github/workflows/check-branch-naming.yml
@@ -1,0 +1,28 @@
+name: Check branch naming convention
+
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - ready_for_review
+
+jobs:
+  branch-name:
+    name: Validate branch naming
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Enforce branch naming convention
+        run: python scripts/ci/check_branch_naming.py
+        env:
+          GITHUB_REF_NAME: ${{ github.head_ref || github.ref_name }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ The goal: reproducibility, composability, and accountability across all agent-dr
 
 3. **Branch naming convention:**  
    ```
-   codex/<task-id>-<slugified-title>
-   # Example: codex/tc-003b-openai-generate-basic
+   codex/tc-XX-description
+   # Example: codex/tc-03-openai-adapter
    ```
 
 4. **Pull Request policy:**  

--- a/docs/contributing/branching.md
+++ b/docs/contributing/branching.md
@@ -1,0 +1,47 @@
+# Branch Naming Convention
+
+Consistent branch names make it possible to trace every change back to its Codex task card. The CI guard `scripts/ci/check_branch_naming.py` enforces the repository-wide pattern and blocks pushes or pull requests that drift from it.
+
+## Pattern
+
+```text
+codex/tc-XX-description
+```
+
+- `codex/` — All automation branches start with the agent prefix.
+- `tc-XX` — Link to the task card identifier. Use two or three digits (for example, `tc-03` or `tc-123`). The CI check is case-insensitive, so `TC-XX` also passes.
+- `description` — A hyphenated slug summarizing the task. Only letters, numbers, and `-` are allowed; prefer lowercase for readability even though the guard is case-insensitive.
+
+The corresponding regular expression is:
+
+```regex
+^codex/tc-[0-9]{2,3}-[a-z0-9-]+$
+```
+
+When compiled in Python the pattern uses `re.IGNORECASE` to tolerate uppercase segments such as `codex/TC-04-enforce-branch-naming`.
+
+## Examples
+
+| Status  | Branch name                               | Notes |
+|---------|-------------------------------------------|-------|
+| ✅ Valid | `codex/tc-03-openai-adapter-scaffolding`  | Two-digit task ID and lowercase slug. |
+| ✅ Valid | `codex/tc-123-ci-regression-fix`          | Three-digit task ID for larger backlogs. |
+| ✅ Valid | `codex/TC-04-enforce-branch-naming`       | Case-insensitive guard accepts uppercase `TC`. |
+| ❌ Invalid | `codex/run-codex-command`                  | Missing task ID segment. |
+| ❌ Invalid | `codex/tc03/foo`                           | Uses `/` instead of a hyphen between ID and slug. |
+| ❌ Invalid | `codex/tc-3-invalid`                       | Task ID must use two or three digits. |
+| ❌ Invalid | `codex/tc-123-title-with spaces`           | Spaces are not allowed; replace with hyphens. |
+
+## Local Validation
+
+The CI workflow `.github/workflows/check-branch-naming.yml` runs automatically on pushes and pull requests. To validate locally, run:
+
+```bash
+python scripts/ci/check_branch_naming.py --branch YOUR_BRANCH_NAME
+```
+
+The script exits with status code `0` when the name matches the pattern. Otherwise it prints:
+
+```
+Branch name must match codex/tc-XX-description pattern (e.g., codex/tc-03-openai-adapter).
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,4 +5,6 @@ nav:
       - IO: io.md
   - Governance:
       - Agents: agents.md
-  - Contributing: contributing.md
+  - Contributing:
+      - Overview: contributing.md
+      - Branch Naming: contributing/branching.md

--- a/scripts/ci/check_branch_naming.py
+++ b/scripts/ci/check_branch_naming.py
@@ -1,0 +1,63 @@
+"""Validate branch naming convention for Codex-driven tasks."""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from typing import Iterable, Mapping
+
+BRANCH_PATTERN = re.compile(r"^codex/tc-[0-9]{2,3}-[a-z0-9-]+$", re.IGNORECASE)
+ERROR_MESSAGE = (
+    "Branch name must match codex/tc-XX-description pattern (e.g., codex/tc-03-openai-adapter)."
+)
+
+
+def is_valid_branch_name(branch: str) -> bool:
+    """Return True when *branch* complies with the enforced naming convention."""
+    if not isinstance(branch, str):
+        return False
+    return bool(BRANCH_PATTERN.fullmatch(branch.strip()))
+
+
+def check_branch(branch: str) -> tuple[bool, str]:
+    """Validate *branch* and return a tuple of success flag and message."""
+    cleaned = branch.strip() if isinstance(branch, str) else ""
+    if not cleaned:
+        return False, "Branch name is not set. Provide --branch or GITHUB_REF_NAME."
+
+    if is_valid_branch_name(cleaned):
+        return True, f"Branch name `{cleaned}` matches the Codex convention."
+
+    return False, ERROR_MESSAGE
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--branch",
+        default=None,
+        help="Override the branch name to validate (defaults to $GITHUB_REF_NAME).",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def determine_branch(env: Mapping[str, str], override: str | None) -> str:
+    if override:
+        return override
+    return env.get("GITHUB_REF_NAME") or env.get("GITHUB_HEAD_REF") or ""
+
+
+def main(argv: Iterable[str] | None = None, env: Mapping[str, str] | None = None) -> int:
+    args = parse_args(argv)
+    environment: Mapping[str, str] = env if env is not None else os.environ
+    branch = determine_branch(environment, args.branch)
+
+    ok, message = check_branch(branch)
+    output = sys.stdout if ok else sys.stderr
+    print(message, file=output)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/scripts/ci/check_pr_closing_ref.py
+++ b/scripts/ci/check_pr_closing_ref.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 import sys
-from typing import Iterable, Mapping, MutableMapping, Tuple
+from typing import Iterable, Mapping, MutableMapping, Tuple, cast
 
 CLOSING_PATTERN = re.compile(
     r"(?im)\b(close|closes|fix|fixes|resolve|resolves)\s+#\d+\b"
@@ -65,7 +65,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 
 def load_event(path: str) -> MutableMapping[str, object]:
     with open(path, "r", encoding="utf-8") as file:
-        return json.load(file)
+        return cast(MutableMapping[str, object], json.load(file))
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/tests/ci/test_check_branch_naming.py
+++ b/tests/ci/test_check_branch_naming.py
@@ -1,0 +1,88 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ci.check_branch_naming import (  # noqa: E402 (import after sys.path setup)
+    ERROR_MESSAGE,
+    check_branch,
+    is_valid_branch_name,
+    main,
+)
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "codex/tc-03-openai-adapter-scaffolding",
+        "codex/tc-42-workflow-hardening",
+        "codex/tc-123-ci-regression-fix",
+        "codex/TC-42-workflow-hardening",
+    ],
+)
+def test_is_valid_branch_name_accepts_compliant_branches(branch: str) -> None:
+    assert is_valid_branch_name(branch)
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "codex/run-codex-command",
+        "codex-tc03",
+        "codex/tc03/foo",
+        "codex/tc-3-invalid",
+        "codex/tc-123-title-with spaces",
+    ],
+)
+def test_is_valid_branch_name_rejects_non_compliant_branches(branch: str) -> None:
+    assert not is_valid_branch_name(branch)
+
+
+@pytest.mark.parametrize(
+    "branch, expected_ok, expected_message",
+    [
+        ("", False, "Branch name is not set. Provide --branch or GITHUB_REF_NAME."),
+        (
+            "codex/tc-03-openai-adapter-scaffolding",
+            True,
+            "Branch name `codex/tc-03-openai-adapter-scaffolding` matches the Codex convention.",
+        ),
+        ("codex/run-codex-command", False, ERROR_MESSAGE),
+    ],
+)
+def test_check_branch_returns_expected_messages(
+    branch: str, expected_ok: bool, expected_message: str
+) -> None:
+    ok, message = check_branch(branch)
+    assert ok is expected_ok
+    assert message == expected_message
+
+
+def test_main_reads_branch_from_github_ref(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("GITHUB_REF_NAME", "codex/tc-42-workflow-hardening")
+    exit_code = main([])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "workflow-hardening" in captured.out
+    assert captured.err == ""
+
+
+def test_main_reports_error_on_invalid_branch(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("GITHUB_REF_NAME", "codex/run-codex-command")
+    exit_code = main([])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert ERROR_MESSAGE in captured.err
+
+
+def test_main_falls_back_to_head_ref(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.setenv("GITHUB_HEAD_REF", "codex/tc-03-openai-adapter-scaffolding")
+    exit_code = main([])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "codex/tc-03-openai-adapter-scaffolding" in captured.out


### PR DESCRIPTION
## Summary
- make the branch naming regex case-insensitive so uppercase segments (e.g. `TC-XX`) pass the check
- extend CI-focused tests to cover uppercase variants and malformed slugs with spaces
- document the case-insensitive behaviour and provide updated examples for contributors

## Testing
- `pytest tests/ci/test_check_branch_naming.py`


------
https://chatgpt.com/codex/tasks/task_e_68f95c790c9083229e48844e4603551e