### PR TITLE
[TC-04] Add non-streaming tool support to OpenAI adapter

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,11 +1,11 @@
 # Adapters
 
-## OpenAI mapping (non-streaming, no tools)
+## OpenAI mapping (non-streaming)
 
 Foundry's OpenAI adapter focuses on deterministic message translation and a
 minimal `generate()` implementation that works with a fake client. The
-implementation avoids network access and omits tool calling or streaming
-support. Instead, it concentrates on the following guarantees:
+implementation avoids network access and streaming support. Instead, it
+concentrates on the following guarantees:
 
 - **Strict schema:** Messages are represented by the `Message` model, which
   enforces one of three roles (`system`, `user`, `assistant`) and requires
@@ -17,7 +17,7 @@ support. Instead, it concentrates on the following guarantees:
   `AdapterError` if data falls outside the supported schema.
 - **Deterministic requests:** `OpenAIAdapter.generate()` injects
   `temperature=0` unless explicitly overridden, prevents caller supplied
-  `messages`/`stream` overrides, and raises an error when tools or streaming are
+  `messages`/`stream` overrides, and raises an error when streaming is
   requested.
 - **Fake client friendly:** Tests construct a fake client exposing
   `chat.completions.create(**kwargs)`. The adapter returns the first assistant
@@ -27,3 +27,34 @@ support. Instead, it concentrates on the following guarantees:
 These primitives establish a baseline for additional capabilities—such as tool
 calling and streaming—to be layered on in future tasks while keeping core
 behavior predictable and well tested.
+
+## Function/Tool calling (non-streaming)
+
+Tool support layers on top of the baseline adapter via the `ToolSpec` and
+`ToolCall` primitives:
+
+- **Declarative tool specs:** `ToolSpec` captures the canonical name,
+  description, and JSON-schema parameters for a tool. Specifications are
+  validated for JSON compatibility, required/optional coherence, and naming
+  rules before being converted into provider payloads.
+- **Provider mapping:** `tool_specs_to_openai()` maps `ToolSpec` instances to
+  OpenAI's `type=function` schema, thawing the immutable parameter structure
+  into JSON-serializable dictionaries. Duplicate tool names and malformed
+  schemas raise `AdapterError` immediately.
+- **Tool call normalization:** `normalize_tool_calls()` converts provider
+  `tool_call` payloads into immutable `ToolCall` records. Arguments are parsed
+  from JSON, validated for structure, and frozen to ensure deterministic
+  comparisons across adapters.
+- **Message conversions:** `messages_to_openai()`/`openai_to_messages()` now
+  include tool call payloads. Assistant messages may carry empty textual
+  content when tool invocations are present, and round-tripping preserves the
+  normalized `ToolCall` tuples.
+- **Adapter integration:** When `tools=[ToolSpec, ...]` is supplied to
+  `OpenAIAdapter.generate()`, the adapter injects the mapped tool definitions
+  into the request and normalizes the resulting tool calls into the returned
+  assistant message. Invalid tool responses propagate as `AdapterError` for
+  deterministic failure handling.
+
+Together, these behaviors ensure the non-streaming tool pathway is type-safe,
+deterministic, and backed by unit plus contract tests that keep Foundry and
+provider semantics aligned.

--- a/src/foundry/core/__init__.py
+++ b/src/foundry/core/__init__.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from .errors import AdapterError
-from .message import Message, MessageRole
+from .message import Message, MessageRole, ToolCall
+from .adapters.toolbridge import ToolSpec
 
 __all__ = [
     "AdapterError",
     "Message",
     "MessageRole",
+    "ToolCall",
+    "ToolSpec",
 ]

--- a/src/foundry/core/adapters/toolbridge.py
+++ b/src/foundry/core/adapters/toolbridge.py
@@ -1,0 +1,283 @@
+"""Mapping helpers between Foundry tool specs and provider schemas."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+import math
+import re
+from types import MappingProxyType
+from typing import Any
+
+from ..errors import AdapterError
+from ..message import ToolCall
+
+_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """Foundry's canonical tool/function description."""
+
+    name: str
+    parameters: Mapping[str, Any]
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not _NAME_PATTERN.fullmatch(self.name):
+            msg = "tool name must match ^[a-zA-Z0-9_-]{1,64}$"
+            raise AdapterError(msg)
+
+        normalized_description: str | None = None
+        if self.description is not None:
+            if not isinstance(self.description, str):
+                msg = "tool description must be a string when provided"
+                raise AdapterError(msg)
+            stripped = self.description.strip()
+            if not stripped:
+                msg = "tool description cannot be empty"
+                raise AdapterError(msg)
+            normalized_description = stripped
+
+        if not isinstance(self.parameters, Mapping):
+            msg = "tool parameters must be a mapping"
+            raise AdapterError(msg)
+
+        raw_parameters = dict(self.parameters)
+        _ensure_json_compatible(raw_parameters, path=f"ToolSpec('{self.name}').parameters")
+
+        try:
+            sanitized = json.loads(json.dumps(raw_parameters, allow_nan=False))
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            msg = "tool parameters must be JSON serializable"
+            raise AdapterError(msg) from exc
+
+        if sanitized.get("type") != "object":
+            msg = "tool parameters must describe a JSON object"
+            raise AdapterError(msg)
+
+        properties = sanitized.get("properties")
+        if properties is None or not isinstance(properties, dict):
+            msg = "tool parameters must include an object 'properties' mapping"
+            raise AdapterError(msg)
+
+        for key in properties:
+            if not isinstance(key, str) or not key:
+                msg = "tool parameter names must be non-empty strings"
+                raise AdapterError(msg)
+
+        required = sanitized.get("required")
+        if required is not None:
+            if not isinstance(required, list):
+                msg = "tool parameter 'required' must be a list of strings"
+                raise AdapterError(msg)
+            for index, item in enumerate(required):
+                if not isinstance(item, str) or not item:
+                    msg = f"required parameter names must be non-empty strings (index {index})"
+                    raise AdapterError(msg)
+                if item not in properties:
+                    msg = f"required parameter '{item}' is not defined"
+                    raise AdapterError(msg)
+
+        frozen_parameters = _freeze_json_structure(sanitized)
+
+        if normalized_description is not None:
+            object.__setattr__(self, "description", normalized_description)
+        object.__setattr__(self, "parameters", frozen_parameters)
+
+
+def tool_specs_to_openai(tool_specs: Sequence[ToolSpec]) -> list[dict[str, Any]]:
+    """Convert Foundry tool specifications to OpenAI's chat tools schema."""
+
+    if isinstance(tool_specs, (str, bytes, bytearray)):
+        msg = "tools must be provided as a sequence of ToolSpec instances"
+        raise AdapterError(msg)
+
+    tools_list = list(tool_specs)
+    normalized_tools: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+
+    for index, spec in enumerate(tools_list):
+        if not isinstance(spec, ToolSpec):
+            msg = f"tools[{index}] must be a ToolSpec"
+            raise AdapterError(msg)
+        if spec.name in seen_names:
+            msg = f"duplicate tool name '{spec.name}'"
+            raise AdapterError(msg)
+        seen_names.add(spec.name)
+
+        function_payload: dict[str, Any] = {
+            "name": spec.name,
+            "parameters": _thaw_json_structure(spec.parameters),
+        }
+        if spec.description is not None:
+            function_payload["description"] = spec.description
+
+        normalized_tools.append({"type": "function", "function": function_payload})
+
+    return normalized_tools
+
+
+def normalize_tool_calls(tool_calls: Sequence[Mapping[str, Any] | Any]) -> tuple[ToolCall, ...]:
+    """Normalize provider tool call payloads into Foundry ToolCall instances."""
+
+    if isinstance(tool_calls, (str, bytes, bytearray)):
+        msg = "tool_calls payload must be a sequence"
+        raise AdapterError(msg)
+
+    normalized: list[ToolCall] = []
+    for index, item in enumerate(tool_calls):
+        mapping = _coerce_mapping(item, path=f"tool_calls[{index}]")
+
+        call_id = mapping.get("id")
+        if not isinstance(call_id, str) or not call_id:
+            msg = f"tool call at index {index} is missing a valid id"
+            raise AdapterError(msg)
+
+        call_type = mapping.get("type")
+        if call_type != "function":
+            msg = f"tool call at index {index} must have type 'function'"
+            raise AdapterError(msg)
+
+        function_payload = mapping.get("function")
+        function_mapping = _coerce_mapping(function_payload, path=f"tool_calls[{index}].function")
+
+        name = function_mapping.get("name")
+        if not isinstance(name, str) or not name:
+            msg = f"tool call at index {index} is missing a valid function name"
+            raise AdapterError(msg)
+
+        raw_arguments = function_mapping.get("arguments", "{}")
+        arguments_mapping = _coerce_arguments(raw_arguments, path=f"tool_calls[{index}].function.arguments")
+
+        normalized.append(ToolCall(id=call_id, name=name, arguments=arguments_mapping))
+
+    return tuple(normalized)
+
+
+def tool_call_to_openai(tool_call: ToolCall) -> dict[str, Any]:
+    """Convert a Foundry ToolCall into the provider representation."""
+
+    if not isinstance(tool_call, ToolCall):  # pragma: no cover - defensive
+        msg = "tool_call must be a ToolCall instance"
+        raise AdapterError(msg)
+
+    thawed_arguments = _thaw_json_structure(tool_call.arguments)
+    try:
+        arguments_json = json.dumps(thawed_arguments, allow_nan=False)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        msg = "tool call arguments must be JSON serializable"
+        raise AdapterError(msg) from exc
+
+    return {
+        "id": tool_call.id,
+        "type": "function",
+        "function": {
+            "name": tool_call.name,
+            "arguments": arguments_json,
+        },
+    }
+
+
+def _coerce_mapping(value: Mapping[str, Any] | Any, *, path: str) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+
+    if hasattr(value, "model_dump"):
+        dump = getattr(value, "model_dump")
+        dumped = dump()
+        if isinstance(dumped, Mapping):
+            return dumped
+
+    msg = f"{path} must be a mapping"
+    raise AdapterError(msg)
+
+
+def _coerce_arguments(raw: Any, *, path: str) -> Mapping[str, Any]:
+    if isinstance(raw, Mapping):
+        mapping = dict(raw)
+    elif isinstance(raw, str):
+        try:
+            parsed = json.loads(raw or "{}")
+        except json.JSONDecodeError as exc:
+            msg = f"{path} must contain valid JSON"
+            raise AdapterError(msg) from exc
+        if not isinstance(parsed, Mapping):
+            msg = f"{path} must decode to a JSON object"
+            raise AdapterError(msg)
+        mapping = dict(parsed)
+    else:
+        msg = f"{path} must be a mapping or JSON string"
+        raise AdapterError(msg)
+
+    _ensure_json_compatible(mapping, path=path)
+
+    try:
+        sanitized = json.loads(json.dumps(mapping, allow_nan=False))
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        msg = f"{path} must contain JSON serializable data"
+        raise AdapterError(msg) from exc
+
+    if not isinstance(sanitized, dict):  # pragma: no cover - defensive
+        msg = f"{path} must decode to a JSON object"
+        raise AdapterError(msg)
+
+    return _freeze_json_structure(sanitized)
+
+
+def _ensure_json_compatible(value: Any, *, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, inner in value.items():
+            if not isinstance(key, str) or not key:
+                msg = f"{path} keys must be non-empty strings"
+                raise AdapterError(msg)
+            _ensure_json_compatible(inner, path=f"{path}.{key}")
+        return
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, item in enumerate(value):
+            _ensure_json_compatible(item, path=f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, type(None), str)):
+        return
+
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            msg = f"{path} contains non-finite float values"
+            raise AdapterError(msg)
+        return
+
+    msg = f"{path} contains unsupported value type {type(value).__name__}"
+    raise AdapterError(msg)
+
+
+def _freeze_json_structure(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, dict):  # pragma: no cover - defensive
+        msg = "expected a dictionary to freeze"
+        raise AdapterError(msg)
+
+    frozen_dict = {key: _freeze_nested_json(inner) for key, inner in value.items()}
+    return MappingProxyType(frozen_dict)
+
+
+def _freeze_nested_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        nested = {key: _freeze_nested_json(inner) for key, inner in value.items()}
+        return MappingProxyType(nested)
+
+    if isinstance(value, list):
+        return tuple(_freeze_nested_json(inner) for inner in value)
+
+    return value
+
+
+def _thaw_json_structure(value: Mapping[str, Any] | Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json_structure(inner) for key, inner in value.items()}
+
+    if isinstance(value, tuple):
+        return [_thaw_json_structure(inner) for inner in value]
+
+    return value

--- a/src/foundry/core/message.py
+++ b/src/foundry/core/message.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
+import json
+import math
+from types import MappingProxyType
+from typing import Any
 
 
 class MessageRole(str, Enum):
@@ -15,16 +20,111 @@ class MessageRole(str, Enum):
 
 
 @dataclass(frozen=True, slots=True)
+class ToolCall:
+    """A provider tool/function invocation emitted by an assistant message."""
+
+    id: str
+    name: str
+    arguments: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id:
+            msg = "tool call id must be a non-empty string"
+            raise ValueError(msg)
+        if not isinstance(self.name, str) or not self.name:
+            msg = "tool call name must be a non-empty string"
+            raise ValueError(msg)
+        if not isinstance(self.arguments, Mapping):
+            msg = "tool call arguments must be a mapping"
+            raise TypeError(msg)
+
+        plain_arguments = _thaw_json_structure(dict(self.arguments))
+        _ensure_json_compatible(plain_arguments, path="ToolCall.arguments")
+
+        sanitized = json.loads(json.dumps(plain_arguments, allow_nan=False))
+        frozen = _freeze_json_structure(sanitized)
+        object.__setattr__(self, "arguments", frozen)
+
+
+@dataclass(frozen=True, slots=True)
 class Message:
     """A single message exchanged with a language model."""
 
     role: MessageRole
     content: str
+    tool_calls: tuple[ToolCall, ...] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.content, str):  # pragma: no cover - defensive
             msg = "message content must be a string"
             raise TypeError(msg)
-        if not self.content:
-            msg = "message content cannot be empty"
+
+        normalized_tool_calls: tuple[ToolCall, ...] | None = None
+        if self.tool_calls is not None:
+            if not isinstance(self.tool_calls, Sequence) or isinstance(
+                self.tool_calls, (str, bytes, bytearray)
+            ):
+                msg = "tool_calls must be a sequence of ToolCall instances"
+                raise TypeError(msg)
+            candidates = tuple(self.tool_calls)
+            if not candidates:
+                msg = "tool_calls cannot be empty"
+                raise ValueError(msg)
+            for call in candidates:
+                if not isinstance(call, ToolCall):
+                    msg = "tool_calls must contain ToolCall instances"
+                    raise TypeError(msg)
+            normalized_tool_calls = candidates
+            object.__setattr__(self, "tool_calls", normalized_tool_calls)
+
+        if self.content == "" and normalized_tool_calls is None:
+            msg = "message content cannot be empty when no tool calls are present"
             raise ValueError(msg)
+
+
+def _ensure_json_compatible(value: Any, *, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, inner in value.items():
+            if not isinstance(key, str) or not key:
+                msg = f"{path} keys must be non-empty strings"
+                raise TypeError(msg)
+            _ensure_json_compatible(inner, path=f"{path}.{key}")
+        return
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, item in enumerate(value):
+            _ensure_json_compatible(item, path=f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, type(None), str)):
+        return
+
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            msg = f"{path} contains non-finite float values"
+            raise ValueError(msg)
+        return
+
+    msg = f"{path} contains unsupported value type {type(value).__name__}"
+    raise TypeError(msg)
+
+
+def _freeze_json_structure(value: Any) -> Any:
+    if isinstance(value, dict):
+        frozen_dict = {key: _freeze_json_structure(inner) for key, inner in value.items()}
+        return MappingProxyType(frozen_dict)
+
+    if isinstance(value, list):
+        return tuple(_freeze_json_structure(inner) for inner in value)
+
+    return value
+
+
+def _thaw_json_structure(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json_structure(inner) for key, inner in value.items()}
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_thaw_json_structure(inner) for inner in value]
+
+    return value

--- a/tests/adapters/test_openai_generate_basic.py
+++ b/tests/adapters/test_openai_generate_basic.py
@@ -69,7 +69,7 @@ def test_generate_rejects_empty_messages() -> None:
         adapter.generate([])
 
 
-def test_generate_rejects_streaming_and_tools() -> None:
+def test_generate_rejects_streaming_option() -> None:
     response = {
         "choices": [
             {"message": {"role": "assistant", "content": "noop"}},
@@ -78,9 +78,6 @@ def test_generate_rejects_streaming_and_tools() -> None:
     client = build_fake_client(response)
     adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
     prompt = [Message(role=MessageRole.USER, content="Hello")]
-
-    with pytest.raises(AdapterError):
-        adapter.generate(prompt, tools=[{"name": "foo"}])
 
     with pytest.raises(AdapterError):
         adapter.generate(prompt, stream=True)

--- a/tests/adapters/test_openai_mapping.py
+++ b/tests/adapters/test_openai_mapping.py
@@ -43,3 +43,30 @@ def test_openai_to_messages_rejects_extra_fields() -> None:
         openai_to_messages([
             {"role": "assistant", "content": "hello", "foo": "bar"},
         ])
+
+
+def test_openai_to_messages_accepts_tool_calls_with_empty_content() -> None:
+    payload = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_tool",
+                    "type": "function",
+                    "function": {
+                        "name": "summarize",
+                        "arguments": "{\"topic\": \"status\"}",
+                    },
+                }
+            ],
+        }
+    ]
+
+    [message] = openai_to_messages(payload)
+
+    assert message.content == ""
+    assert message.tool_calls is not None
+    [tool_call] = message.tool_calls
+    assert tool_call.name == "summarize"
+    assert tool_call.arguments["topic"] == "status"

--- a/tests/adapters/test_openai_tools.py
+++ b/tests/adapters/test_openai_tools.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from foundry.core import AdapterError, Message, MessageRole, ToolCall
+from foundry.core.adapters.openai import OpenAIAdapter
+from foundry.core.adapters.toolbridge import (
+    ToolSpec,
+    normalize_tool_calls,
+    tool_specs_to_openai,
+)
+from foundry.core.adapters.utils import messages_to_openai
+
+
+class FakeCompletions:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        return self._response
+
+
+def build_fake_client(response: object) -> SimpleNamespace:
+    completions = FakeCompletions(response)
+    chat = SimpleNamespace(completions=completions)
+    return SimpleNamespace(chat=chat, completions=completions)
+
+
+def build_weather_spec() -> ToolSpec:
+    return ToolSpec(
+        name="get_weather",
+        description="Return weather observations for a location",
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "City name to resolve",
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": ["celsius", "fahrenheit"],
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "lat": {"type": "number"},
+                        "lon": {"type": "number"},
+                    },
+                    "required": ["lat", "lon"],
+                },
+            },
+            "required": ["location"],
+        },
+    )
+
+
+def test_tool_spec_mapping_includes_nested_properties() -> None:
+    spec = build_weather_spec()
+
+    tools_payload = tool_specs_to_openai([spec])
+
+    assert tools_payload == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Return weather observations for a location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "City name to resolve",
+                        },
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "properties": {
+                                "lat": {"type": "number"},
+                                "lon": {"type": "number"},
+                            },
+                            "required": ["lat", "lon"],
+                        },
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+
+
+def test_tool_spec_validation_rejects_invalid_schema() -> None:
+    with pytest.raises(AdapterError):
+        ToolSpec(
+            name="bad-tool",
+            parameters={"type": "array", "items": {}},
+        )
+
+
+def test_tool_spec_validation_rejects_duplicate_names() -> None:
+    spec = build_weather_spec()
+
+    with pytest.raises(AdapterError):
+        tool_specs_to_openai([spec, spec])
+
+
+def test_normalize_tool_calls_parses_arguments() -> None:
+    payload = [
+        {
+            "id": "call_abc",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": json.dumps(
+                    {
+                        "location": "Berlin",
+                        "unit": "celsius",
+                        "metadata": {"lat": 52.5, "lon": 13.4},
+                    },
+                    allow_nan=False,
+                ),
+            },
+        }
+    ]
+
+    [tool_call] = normalize_tool_calls(payload)
+
+    assert tool_call.id == "call_abc"
+    assert tool_call.name == "get_weather"
+    assert tool_call.arguments["location"] == "Berlin"
+    assert tool_call.arguments["metadata"]["lat"] == 52.5
+
+
+def test_normalize_tool_calls_rejects_invalid_json() -> None:
+    payload = [
+        {
+            "id": "call_bad",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": "{not json}",
+            },
+        }
+    ]
+
+    with pytest.raises(AdapterError):
+        normalize_tool_calls(payload)
+
+
+def test_generate_returns_message_with_tool_calls() -> None:
+    spec = build_weather_spec()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_weather",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": json.dumps(
+                                    {
+                                        "location": "Paris",
+                                        "unit": "celsius",
+                                    },
+                                    allow_nan=False,
+                                ),
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+
+    prompt = [
+        Message(role=MessageRole.SYSTEM, content="Weather agent"),
+        Message(role=MessageRole.USER, content="Temperature in Paris?"),
+    ]
+
+    assistant = adapter.generate(prompt, tools=[spec])
+
+    assert assistant.content == ""
+    assert assistant.tool_calls is not None
+    [tool_call] = assistant.tool_calls
+    assert tool_call.id == "call_weather"
+    assert tool_call.arguments["location"] == "Paris"
+
+    [call] = client.completions.calls
+    assert "tools" in call
+    assert call["tools"] == tool_specs_to_openai([spec])
+
+
+def test_generate_rejects_invalid_tool_response() -> None:
+    spec = build_weather_spec()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_weather",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": "not json",
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+
+    prompt = [Message(role=MessageRole.USER, content="Temperature in Paris?")]
+
+    with pytest.raises(AdapterError):
+        adapter.generate(prompt, tools=[spec])
+
+
+def test_messages_to_openai_includes_tool_calls() -> None:
+    tool_call = ToolCall(
+        id="call_1",
+        name="get_weather",
+        arguments={"location": "Lisbon", "unit": "fahrenheit"},
+    )
+    message = Message(
+        role=MessageRole.ASSISTANT,
+        content="",
+        tool_calls=(tool_call,),
+    )
+
+    payload = messages_to_openai([message])
+
+    assert payload == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": json.dumps(
+                            {"location": "Lisbon", "unit": "fahrenheit"},
+                            allow_nan=False,
+                        ),
+                    },
+                }
+            ],
+        }
+    ]

--- a/tests/contracts/test_adapter_tools_api.py
+++ b/tests/contracts/test_adapter_tools_api.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from foundry.core import Message, MessageRole
+from foundry.core.adapters.openai import OpenAIAdapter
+from foundry.core.adapters.toolbridge import ToolSpec, normalize_tool_calls, tool_specs_to_openai
+from foundry.core.adapters.utils import messages_to_openai
+
+
+class FakeCompletions:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        return self._response
+
+
+def build_fake_client(response: object) -> SimpleNamespace:
+    completions = FakeCompletions(response)
+    chat = SimpleNamespace(completions=completions)
+    return SimpleNamespace(chat=chat, completions=completions)
+
+
+def build_specs() -> list[ToolSpec]:
+    return [
+        ToolSpec(
+            name="get_weather",
+            description="Lookup the weather for a location",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        ),
+        ToolSpec(
+            name="get_time",
+            description="Return current time for a timezone",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "timezone": {"type": "string"},
+                },
+                "required": ["timezone"],
+            },
+        ),
+    ]
+
+
+def test_openai_tool_normalization_matches_bridge() -> None:
+    specs = build_specs()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_weather",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": json.dumps(
+                                    {"location": "Rome", "unit": "celsius"},
+                                    allow_nan=False,
+                                ),
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    client = build_fake_client(response)
+    adapter = OpenAIAdapter(client, default_model="gpt-4o-mini")
+
+    prompt = [Message(role=MessageRole.USER, content="Weather in Rome?")]
+
+    assistant = adapter.generate(prompt, tools=specs)
+
+    assert assistant.tool_calls is not None
+    expected_calls = normalize_tool_calls(response["choices"][0]["message"]["tool_calls"])
+    assert assistant.tool_calls == expected_calls
+
+    round_trip_payload = messages_to_openai([assistant])[0]["tool_calls"]
+    assert normalize_tool_calls(round_trip_payload) == expected_calls
+
+    [call] = client.completions.calls
+    assert call["tools"] == tool_specs_to_openai(specs)


### PR DESCRIPTION
## Summary
- add ToolSpec/ToolCall primitives and mapping utilities for OpenAI tool payloads
- extend the OpenAI adapter and message conversions to normalize non-streaming tool calls
- cover the tool path with focused unit tests, a contract test, and updated adapter docs

## Testing
- pytest -q tests/adapters/test_openai_generate_basic.py tests/adapters/test_openai_mapping.py tests/adapters/test_openai_tools.py tests/contracts/test_adapter_tools_api.py
- mypy --strict src/foundry/core/adapters

Closes #19 
------
https://chatgpt.com/codex/tasks/task_e_68f973e92ffc8322adba941289909650