### PR TITLE
[TC-05-A] Define Canonical Streaming Event Schema and Base Iterator

### DIFF
--- a/src/foundry/core/adapters/__init__.py
+++ b/src/foundry/core/adapters/__init__.py
@@ -4,11 +4,25 @@ from __future__ import annotations
 
 from .base import ModelAdapter
 from .openai import OpenAIAdapter
+from .stream import (
+    BaseStreamIterator,
+    FinalEvent,
+    StreamEvent,
+    TokenEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+)
 from .utils import messages_to_openai, openai_to_messages
 
 __all__ = [
     "ModelAdapter",
     "OpenAIAdapter",
+    "BaseStreamIterator",
+    "TokenEvent",
+    "ToolCallEvent",
+    "ToolResultEvent",
+    "FinalEvent",
+    "StreamEvent",
     "messages_to_openai",
     "openai_to_messages",
 ]

--- a/src/foundry/core/adapters/stream.py
+++ b/src/foundry/core/adapters/stream.py
@@ -1,0 +1,140 @@
+"""Canonical streaming event schema and base iterator primitives."""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Deque, Dict, List, Optional, Protocol, Union
+
+
+@dataclass(slots=True)
+class TokenEvent:
+    """Incremental assistant token emitted during streaming generation."""
+
+    content: str
+    index: int
+
+
+@dataclass(slots=True)
+class ToolCallEvent:
+    """Partial tool invocation emitted while arguments are streamed."""
+
+    id: str
+    name: str
+    args_fragment: str
+    is_final: bool = False
+
+
+@dataclass(slots=True)
+class ToolResultEvent:
+    """Result payload returned from a previously announced tool call."""
+
+    id: str
+    output: str
+
+
+@dataclass(slots=True)
+class FinalEvent:
+    """Terminal event containing the consolidated assistant output."""
+
+    output: str
+    total_tokens: Optional[int] = None
+
+
+StreamEvent = Union[TokenEvent, ToolCallEvent, ToolResultEvent, FinalEvent]
+
+
+class BaseStreamIterator(AsyncIterator[StreamEvent], metaclass=abc.ABCMeta):
+    """Shared async iterator driving provider-specific streaming adapters.
+
+    Subclasses are responsible for sourcing raw provider chunks by
+    implementing :meth:`_get_next_chunk`. Each chunk is normalized into one or
+    more :class:`StreamEvent` instances via a :class:`StreamNormalizer`. The
+    iterator buffers normalized events so consumers receive a linear stream of
+    canonical event objects regardless of how providers batch their updates.
+    """
+
+    def __init__(self, normalizer: StreamNormalizer) -> None:
+        self._normalizer = normalizer
+        self._buffer: Deque[StreamEvent] = deque()
+        self._closed = False
+        self._finalized = False
+        self._close_lock = asyncio.Lock()
+
+    def __aiter__(self) -> BaseStreamIterator:
+        return self
+
+    async def __anext__(self) -> StreamEvent:
+        if self._closed and not self._buffer:
+            raise StopAsyncIteration
+
+        if self._finalized and not self._buffer:
+            await self.close()
+            raise StopAsyncIteration
+
+        buffered = self._pop_buffered_event()
+        if buffered is not None:
+            return await self._finalize_if_needed(buffered)
+
+        while True:
+            if self._closed:
+                raise StopAsyncIteration
+
+            if self._finalized:
+                await self.close()
+                raise StopAsyncIteration
+
+            chunk = await self._consume_chunk()
+            events = await self._normalizer.normalize_chunk(chunk)
+            if not events:
+                continue
+
+            self._buffer.extend(events)
+            buffered = self._pop_buffered_event()
+            if buffered is not None:
+                return await self._finalize_if_needed(buffered)
+
+    async def close(self) -> None:
+        """Release provider resources and prevent additional iteration."""
+
+        async with self._close_lock:
+            if self._closed:
+                return
+
+            self._closed = True
+            self._buffer.clear()
+            await self._on_close()
+
+    async def _consume_chunk(self) -> Dict[str, Any]:
+        try:
+            return await self._get_next_chunk()
+        except StopAsyncIteration:
+            await self.close()
+            raise
+
+    async def _finalize_if_needed(self, event: StreamEvent) -> StreamEvent:
+        if isinstance(event, FinalEvent):
+            self._finalized = True
+            if not self._buffer:
+                await self.close()
+        return event
+
+    def _pop_buffered_event(self) -> StreamEvent | None:
+        if not self._buffer:
+            return None
+        return self._buffer.popleft()
+
+    @abc.abstractmethod
+    async def _get_next_chunk(self) -> Dict[str, Any]:
+        """Retrieve the next raw chunk from the provider stream."""
+
+    async def _on_close(self) -> None:
+        """Allow subclasses to dispose provider resources when closing."""
+
+
+class StreamNormalizer(Protocol):
+    async def normalize_chunk(self, chunk: Dict[str, Any]) -> List[StreamEvent]:
+        """Map a provider-specific chunk into canonical stream events."""
+

--- a/tests/adapters/test_stream_events.py
+++ b/tests/adapters/test_stream_events.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import is_dataclass
+from typing import Any, Dict, Iterable, List
+
+import pytest
+
+from foundry.core.adapters.stream import (
+    BaseStreamIterator,
+    FinalEvent,
+    StreamEvent,
+    StreamNormalizer,
+    TokenEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+
+
+def test_event_dataclasses_are_slot_based() -> None:
+    assert is_dataclass(TokenEvent)
+    assert is_dataclass(ToolCallEvent)
+    assert is_dataclass(ToolResultEvent)
+    assert is_dataclass(FinalEvent)
+
+    for cls, expected_slots in (
+        (TokenEvent, {"content", "index"}),
+        (ToolCallEvent, {"id", "name", "args_fragment", "is_final"}),
+        (ToolResultEvent, {"id", "output"}),
+        (FinalEvent, {"output", "total_tokens"}),
+    ):
+        assert set(getattr(cls, "__slots__")) == expected_slots
+
+
+class DummyNormalizer(StreamNormalizer):
+    def __init__(self, responses: Iterable[List[StreamEvent]]) -> None:
+        self._responses = iter(responses)
+        self.seen_chunks: List[Dict[str, Any]] = []
+
+    async def normalize_chunk(self, chunk: Dict[str, Any]) -> List[StreamEvent]:
+        self.seen_chunks.append(chunk)
+        try:
+            return next(self._responses)
+        except StopIteration:
+            return []
+
+
+class DummyStream(BaseStreamIterator):
+    def __init__(self, *, chunks: Iterable[Dict[str, Any]], normalizer: StreamNormalizer) -> None:
+        super().__init__(normalizer)
+        self._chunks = iter(chunks)
+        self.closed = False
+        self.close_count = 0
+
+    async def _get_next_chunk(self) -> Dict[str, Any]:
+        try:
+            return next(self._chunks)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+    async def _on_close(self) -> None:
+        self.close_count += 1
+        self.closed = True
+
+
+def test_iterator_streams_normalized_events() -> None:
+    chunks = [{"id": 1}, {"id": 2}, {"id": 3}]
+    normalizer = DummyNormalizer(
+        responses=[
+            [TokenEvent(content="Hel", index=0), TokenEvent(content="lo", index=1)],
+            [
+                ToolCallEvent(
+                    id="call-1",
+                    name="do",
+                    args_fragment="{\"x\":",
+                    is_final=False,
+                ),
+                ToolCallEvent(
+                    id="call-1",
+                    name="do",
+                    args_fragment="1}",
+                    is_final=True,
+                ),
+            ],
+            [
+                ToolResultEvent(id="call-1", output="ok"),
+                FinalEvent(output="Hello", total_tokens=4),
+            ],
+        ]
+    )
+
+    stream = DummyStream(chunks=chunks, normalizer=normalizer)
+
+    async def _gather() -> List[StreamEvent]:
+        return [event async for event in stream]
+
+    events = asyncio.run(_gather())
+
+    assert events == [
+        TokenEvent(content="Hel", index=0),
+        TokenEvent(content="lo", index=1),
+        ToolCallEvent(id="call-1", name="do", args_fragment='{"x":', is_final=False),
+        ToolCallEvent(id="call-1", name="do", args_fragment="1}", is_final=True),
+        ToolResultEvent(id="call-1", output="ok"),
+        FinalEvent(output="Hello", total_tokens=4),
+    ]
+    assert stream.close_count == 1
+    assert stream.closed
+    assert normalizer.seen_chunks == chunks
+
+
+def test_iterator_skips_empty_batches_and_stops_after_final_event() -> None:
+    chunks = [{"id": "empty"}, {"id": "payload"}, {"id": "ignored"}]
+    normalizer = DummyNormalizer(
+        responses=[
+            [],
+            [TokenEvent(content="A", index=0), FinalEvent(output="done")],
+            [TokenEvent(content="extra", index=1)],
+        ]
+    )
+
+    stream = DummyStream(chunks=chunks, normalizer=normalizer)
+
+    async def _gather() -> List[StreamEvent]:
+        return [event async for event in stream]
+
+    events = asyncio.run(_gather())
+
+    assert events == [TokenEvent(content="A", index=0), FinalEvent(output="done")]
+    # The iterator closes as soon as the final event is emitted.
+    assert stream.close_count == 1
+    assert normalizer.seen_chunks == chunks[:2]
+
+
+def test_close_is_idempotent_and_prevents_additional_reads() -> None:
+    normalizer = DummyNormalizer(responses=[[TokenEvent(content="x", index=0)]])
+    stream = DummyStream(chunks=[{"id": 1}], normalizer=normalizer)
+
+    asyncio.run(stream.close())
+    asyncio.run(stream.close())
+
+    assert stream.close_count == 1
+    assert stream.closed
+
+    async def _anext() -> StreamEvent:
+        return await anext(stream)
+
+    with pytest.raises(StopAsyncIteration):
+        asyncio.run(_anext())


### PR DESCRIPTION
## Summary
- add canonical streaming event dataclasses and a reusable BaseStreamIterator wired to a normalizer
- expose the streaming primitives via the adapters package and document the streaming event schema
- cover the canonical events and iterator lifecycle with unit tests

## Testing
- pytest tests/adapters/test_stream_events.py
- pytest tests/adapters -q
- ruff check src/foundry/core/adapters/stream.py tests/adapters/test_stream_events.py

Closes #23 
------
https://chatgpt.com/codex/tasks/task_e_68f9a4722e5883228bb8181c9854ad51