### PR TITLE
[TC-05-B] Add deterministic mock streaming client

### DIFF
--- a/tests/adapters/test_openai_streaming_mock.py
+++ b/tests/adapters/test_openai_streaming_mock.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+
+from foundry.core.adapters.stream import (
+    FinalEvent,
+    MockStreamIterator,
+    TokenEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    replay_stream,
+)
+
+
+def test_simple_scenario_emits_expected_events() -> None:
+    iterator = MockStreamIterator("simple")
+
+    events = asyncio.run(replay_stream(iterator))
+
+    assert events == [
+        TokenEvent(content="Hello", index=0),
+        TokenEvent(content=", world", index=1),
+        FinalEvent(output="Hello, world", total_tokens=4),
+    ]
+    assert [type(event) for event in events] == [TokenEvent, TokenEvent, FinalEvent]
+
+
+def test_tool_call_scenario_is_deterministic() -> None:
+    first_run = asyncio.run(replay_stream(MockStreamIterator("tool_call")))
+    second_run = asyncio.run(replay_stream(MockStreamIterator("tool_call")))
+
+    assert first_run == [
+        TokenEvent(content="Calling calculator", index=0),
+        ToolCallEvent(
+            id="tool-1",
+            name="sum",
+            args_fragment="{\"a\": 1",
+            is_final=False,
+        ),
+        ToolCallEvent(
+            id="tool-1",
+            name="sum",
+            args_fragment=", \"b\": 3}",
+            is_final=True,
+        ),
+        ToolResultEvent(id="tool-1", output="Sum is 4"),
+        FinalEvent(output="Sum is 4", total_tokens=6),
+    ]
+    assert [type(event) for event in first_run] == [
+        TokenEvent,
+        ToolCallEvent,
+        ToolCallEvent,
+        ToolResultEvent,
+        FinalEvent,
+    ]
+    assert first_run == second_run


### PR DESCRIPTION
## Summary
- implement `MockStreamIterator` and `replay_stream` helper to provide deterministic streaming events
- add adapter tests covering the "simple" and "tool_call" mock scenarios
- document the mock client usage and event timelines in the adapters guide

## Testing
- `pytest -q tests/adapters/test_openai_streaming_mock.py`
- `mypy --strict src/foundry/core/adapters/stream.py tests/adapters/test_openai_streaming_mock.py`
- `ruff check src/foundry/core/adapters/stream.py tests/adapters/test_openai_streaming_mock.py`

Closes #24 
------
https://chatgpt.com/codex/tasks/task_e_68fa506b8afc8322875eb39fc9503e3a