### PR TITLE
[TC-05-C] Add streaming replay helper for parity validation

### DIFF
--- a/tests/adapters/test_stream_replay.py
+++ b/tests/adapters/test_stream_replay.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+from foundry.core.adapters.stream import (
+    FinalEvent,
+    MockStreamIterator,
+    TokenEvent,
+    replay_events,
+)
+
+
+def test_replay_events_collapses_mock_stream_output() -> None:
+    iterator = MockStreamIterator("simple")
+
+    result = asyncio.run(replay_events(iterator))
+
+    assert result == "Hello, world"
+    assert getattr(iterator, "_closed")
+
+
+def test_replay_events_handles_token_only_stream() -> None:
+    async def _token_stream() -> AsyncIterator[TokenEvent | FinalEvent]:
+        yield TokenEvent(content="Alpha", index=0)
+        yield TokenEvent(content="Beta", index=1)
+
+    result = asyncio.run(replay_events(_token_stream()))
+
+    assert result == "AlphaBeta"
+
+
+def test_replay_events_appends_mismatched_final_output() -> None:
+    async def _mismatched_stream() -> AsyncIterator[TokenEvent | FinalEvent]:
+        yield TokenEvent(content="Partial", index=0)
+        yield FinalEvent(output="Complete")
+
+    result = asyncio.run(replay_events(_mismatched_stream()))
+
+    assert result == "PartialComplete"


### PR DESCRIPTION
## Summary
- add a replay_events helper that collapses streamed token fragments and final output into a single string while ensuring iterators are closed
- cover replay_events with unit tests for mock, token-only, and mismatched final output scenarios

## Testing
- pytest tests/adapters/test_stream_replay.py

Closes #25 
------
https://chatgpt.com/codex/tasks/task_e_68fa70248620832293d03f6a10317182