### PR TITLE
Add adapter harness and deterministic OpenAI streaming fixtures

### DIFF
--- a/src/foundry/core/adapters/openai.py
+++ b/src/foundry/core/adapters/openai.py
@@ -22,6 +22,12 @@ from .toolbridge import ToolSpec, tool_specs_to_openai
 from .utils import messages_to_openai, openai_to_messages
 
 
+def create_openai_stream(client: Any, payload: Mapping[str, Any]) -> Any:
+    """Create a streaming iterator using the provided OpenAI client."""
+
+    return client.chat.completions.create(**payload)
+
+
 class OpenAIAdapter(ModelAdapter):
     """Translate Foundry messages to OpenAI's chat completion API."""
 
@@ -114,7 +120,7 @@ class OpenAIAdapter(ModelAdapter):
         request_payload["stream"] = True
 
         try:
-            stream = self._client.chat.completions.create(**request_payload)
+            stream = create_openai_stream(self._client, request_payload)
         except Exception as exc:  # pragma: no cover - transport errors
             msg = "OpenAI client call failed"
             raise AdapterError(msg) from exc

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package for Foundry."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,21 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
+from tests.fixtures import openai_fake
+
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture(autouse=True)
+def patch_openai_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure OpenAI streaming uses deterministic fake fixtures."""
+
+    monkeypatch.setattr(
+        "foundry.core.adapters.openai.create_openai_stream",
+        openai_fake.create_openai_stream,
+    )

--- a/tests/fixtures/openai_fake.py
+++ b/tests/fixtures/openai_fake.py
@@ -1,0 +1,127 @@
+"""Deterministic OpenAI streaming fixtures for offline adapter tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from types import SimpleNamespace
+from typing import Any, Deque, Iterable, Mapping, Sequence
+
+StreamChunk = Mapping[str, Any]
+
+
+class FakeAsyncStream:
+    """Async iterator that replays pre-defined OpenAI chunks."""
+
+    def __init__(self, chunks: Iterable[StreamChunk]) -> None:
+        self._chunks: Deque[dict[str, Any]] = deque(dict(chunk) for chunk in chunks)
+        self.closed = False
+
+    def __aiter__(self) -> "FakeAsyncStream":
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        if not self._chunks:
+            raise StopAsyncIteration
+        await asyncio.sleep(0)
+        return self._chunks.popleft()
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FakeCompletions:
+    """Minimal stub for ``client.chat.completions``."""
+
+    def __init__(self, stream: FakeAsyncStream) -> None:
+        self._stream = stream
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> FakeAsyncStream:
+        self.calls.append(dict(kwargs))
+        return self._stream
+
+
+def build_streaming_client(chunks: Sequence[StreamChunk]) -> tuple[SimpleNamespace, FakeAsyncStream]:
+    """Return a fake OpenAI client and associated stream for the given chunks."""
+
+    stream = FakeAsyncStream(chunks)
+    completions = FakeCompletions(stream)
+    chat = SimpleNamespace(completions=completions)
+    client = SimpleNamespace(chat=chat, completions=completions)
+    return client, stream
+
+
+def token_only_chunks() -> list[dict[str, Any]]:
+    """OpenAI chunks representing a token-only streaming response."""
+
+    return [
+        {"choices": [{"index": 0, "delta": {"content": "Hello"}}]},
+        {"choices": [{"index": 0, "delta": {"content": ", world"}}]},
+        {
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"total_tokens": 4},
+        },
+    ]
+
+
+def tool_call_chunks() -> list[dict[str, Any]]:
+    """OpenAI chunks representing a streaming tool call flow."""
+
+    return [
+        {"choices": [{"index": 0, "delta": {"content": "Calling calculator"}}]},
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "tool-1",
+                                "type": "function",
+                                "function": {"name": "sum", "arguments": '{"a": 1'},
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"arguments": ', "b": 3}'},
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        },
+        {"tool_result": {"id": "tool-1", "output": "Sum is 4"}},
+        {
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"total_tokens": 6},
+        },
+    ]
+
+
+def create_openai_stream(client: Any, payload: Mapping[str, Any]) -> FakeAsyncStream:
+    """Replica of the adapter's streaming factory that records invocations."""
+
+    return client.completions.create(**payload)
+
+
+__all__ = [
+    "FakeAsyncStream",
+    "FakeCompletions",
+    "build_streaming_client",
+    "create_openai_stream",
+    "token_only_chunks",
+    "tool_call_chunks",
+]

--- a/tests/harness/__init__.py
+++ b/tests/harness/__init__.py
@@ -1,0 +1,9 @@
+"""Test harness utilities for adapter validation."""
+
+from .adapter_harness import BaseEvent, collect, collect_async
+
+__all__ = [
+    "BaseEvent",
+    "collect",
+    "collect_async",
+]

--- a/tests/harness/adapter_harness.py
+++ b/tests/harness/adapter_harness.py
@@ -1,0 +1,156 @@
+"""Reusable harness utilities for validating streaming adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Literal, Sequence
+
+from foundry.core.adapters.base import ModelAdapter
+from foundry.core.adapters.stream import (
+    FinalEvent as _FinalEvent,
+    StreamEvent,
+    TokenEvent as _TokenEvent,
+    ToolCallEvent as _ToolCallEvent,
+    ToolResultEvent as _ToolResultEvent,
+    replay_stream,
+)
+from foundry.core.message import Message, MessageRole
+
+EventType = Literal["token", "tool_call", "tool_result", "final"]
+
+
+@dataclass(slots=True)
+class BaseEvent:
+    """Canonical representation of adapter streaming events."""
+
+    type: EventType
+    content: str | None = None
+    index: int | None = None
+    id: str | None = None
+    name: str | None = None
+    args_fragment: str | None = None
+    is_final: bool | None = None
+    output: str | None = None
+    total_tokens: int | None = None
+
+    @classmethod
+    def token(cls, *, content: str, index: int) -> "BaseEvent":
+        return cls("token", content=content, index=index)
+
+    @classmethod
+    def tool_call(
+        cls,
+        *,
+        id: str,
+        name: str,
+        args_fragment: str,
+        is_final: bool,
+    ) -> "BaseEvent":
+        return cls(
+            "tool_call",
+            id=id,
+            name=name,
+            args_fragment=args_fragment,
+            is_final=is_final,
+        )
+
+    @classmethod
+    def tool_result(cls, *, id: str, output: str) -> "BaseEvent":
+        return cls("tool_result", id=id, output=output)
+
+    @classmethod
+    def final(
+        cls,
+        *,
+        output: str,
+        total_tokens: int | None = None,
+    ) -> "BaseEvent":
+        return cls("final", output=output, total_tokens=total_tokens)
+
+    @classmethod
+    def from_stream_event(cls, event: StreamEvent) -> "BaseEvent":
+        if isinstance(event, _TokenEvent):
+            return cls.token(content=event.content, index=event.index)
+        if isinstance(event, _ToolCallEvent):
+            return cls.tool_call(
+                id=event.id,
+                name=event.name,
+                args_fragment=event.args_fragment,
+                is_final=event.is_final,
+            )
+        if isinstance(event, _ToolResultEvent):
+            return cls.tool_result(id=event.id, output=event.output)
+        if isinstance(event, _FinalEvent):
+            return cls.final(output=event.output, total_tokens=event.total_tokens)
+        msg = f"unsupported stream event type: {type(event).__name__}"
+        raise TypeError(msg)
+
+
+async def collect_async(
+    adapter: ModelAdapter,
+    *,
+    prompt: str | None = None,
+    messages: Sequence[Message] | None = None,
+    system_prompt: str | None = "Harness system",
+    tools: Sequence[Any] | None = None,
+) -> list[BaseEvent]:
+    """Collect streaming events from an adapter using the provided prompt."""
+
+    normalized = _resolve_messages(prompt=prompt, messages=messages, system_prompt=system_prompt)
+    iterator = adapter.stream(normalized, tools=tools)
+    events = await replay_stream(iterator)
+    return [BaseEvent.from_stream_event(event) for event in events]
+
+
+def collect(
+    adapter: ModelAdapter,
+    *,
+    prompt: str | None = None,
+    messages: Sequence[Message] | None = None,
+    system_prompt: str | None = "Harness system",
+    tools: Sequence[Any] | None = None,
+) -> list[BaseEvent]:
+    """Synchronous wrapper around :func:`collect_async`."""
+
+    return asyncio.run(
+        collect_async(
+            adapter,
+            prompt=prompt,
+            messages=messages,
+            system_prompt=system_prompt,
+            tools=tools,
+        )
+    )
+
+
+def _resolve_messages(
+    *,
+    prompt: str | None,
+    messages: Sequence[Message] | None,
+    system_prompt: str | None,
+) -> list[Message]:
+    if prompt is not None and messages is not None:
+        msg = "provide either 'prompt' or 'messages', not both"
+        raise ValueError(msg)
+
+    if prompt is None and messages is None:
+        msg = "either 'prompt' or 'messages' must be provided"
+        raise ValueError(msg)
+
+    if prompt is not None:
+        resolved: list[Message] = []
+        if system_prompt is not None:
+            resolved.append(Message(role=MessageRole.SYSTEM, content=system_prompt))
+        resolved.append(Message(role=MessageRole.USER, content=prompt))
+        return resolved
+
+    resolved = list(messages or ())
+    for index, message in enumerate(resolved):
+        if not isinstance(message, Message):
+            msg = f"messages[{index}] must be a Message instance"
+            raise TypeError(msg)
+    return resolved
+
+
+__all__ = ["BaseEvent", "collect", "collect_async"]


### PR DESCRIPTION
## Summary
- add a reusable streaming harness that normalizes adapter events into BaseEvent records
- introduce deterministic OpenAI streaming fixtures and autouse monkeypatch for tests
- refresh OpenAI streaming tests to use the harness and fake stream helper

## Testing
- pytest tests/adapters/test_openai_streaming_adapter.py

Closes #33 

------
https://chatgpt.com/codex/tasks/task_e_68faa9f7bb048322b789ad02768dffa2