### PR TITLE
Add TC-06 fast-fail adapter gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: TC-06 Fast-Fail Gate
+
+on:
+  pull_request:
+    paths:
+      - 'src/foundry/adapters/**'
+      - 'tests/**'
+
+jobs:
+  tc-06:
+    name: TC-06 adapter contract & parity
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev] ruff mypy pydantic
+
+      - name: TC-06 adapter contract & parity
+        run: scripts/ci/check_tc06.sh

--- a/scripts/ci/check_tc06.sh
+++ b/scripts/ci/check_tc06.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+ruff check .
+mypy .
+pytest -q -k "openai_adapter_"


### PR DESCRIPTION
## Summary
- add a TC-06 workflow that runs on adapter or test changes and executes the fast-fail gate
- implement scripts/ci/check_tc06.sh to run ruff, mypy, and the targeted pytest filter

## Testing
- ❌ `pytest -q -k "openai_adapter_"` *(missing pydantic dependency in the execution environment)*

Closes #34 
------
https://chatgpt.com/codex/tasks/task_e_68faaa0612c08322b41ce07c174e2c85