### PR TITLE
Enhance check_tc06.sh to clean prior artifacts

### DIFF
--- a/scripts/ci/check_tc06.sh
+++ b/scripts/ci/check_tc06.sh
@@ -1,9 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repo root and enter it
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+# Keep repo root on sys.path for any tests that import local packages
+export PYTHONPATH="${ROOT_DIR}"
+
+# ---- Clean prior build/test artifacts that can confuse mypy/pytest ----
+rm -rf build/ dist/ .mypy_cache/ .pytest_cache/ .ruff_cache/ *.egg-info
+
+echo "== Ruff =="
 ruff check .
-mypy .
+
+echo "== Mypy =="
+# Point mypy at 'src' only to avoid picking up build/lib duplicates.
+# '--explicit-package-bases' keeps imports unambiguous in a src/ layout.
+mypy src --explicit-package-bases
+
+echo "== Pytest (TC-06 adapter contract & parity) =="
+# Run just the TC-06 adapter tests (pattern can be adjusted as needed)
 pytest -q -k "openai_adapter_"
+
+echo "All TC-06 checks passed."


### PR DESCRIPTION
This script now cleans up prior build/test artifacts before running checks.

## Related Task Card
- Closes #45 

## Summary
-

## Review Brief
- CI will post a Review Brief comment. Ensure risk/coverage/API sections look correct before requesting review.

## Verification
- [ ] Tests
- [ ] mypy
- [ ] Coverage
